### PR TITLE
feat(slack-bridge): add process-scoped follower startup

### DIFF
--- a/slack-bridge/README.md
+++ b/slack-bridge/README.md
@@ -238,6 +238,18 @@ This is separate from `allowedUsers`. Authorization decides who can use Pinet. T
 | `meshSecret`             | Shared secret for mesh auth                            | none                 |
 | `meshSecretPath`         | File containing shared secret                          | none                 |
 
+### Start one process as a follower
+
+Use the process-scoped flag when one Pi process, including a headless or launchd process, must follow the existing broker without changing shared settings:
+
+```bash
+pi --pinet-follow
+```
+
+`--pinet-follow` overrides `runtimeMode` and the legacy auto flags for that process only. It does not modify `settings.json`, bypass mesh authentication, or allow local subagent sessions to enter the mesh. Set `PINET_SOCKET_PATH` when the broker uses a non-default Unix socket; startup and the follower client resolve the same path.
+
+The follower registers with the broker before Slack, Pinet, or iMessage communication tools become active. If the socket is missing or broker authentication/registration fails, Pi logs an actionable error and continues with those communication tools off. It never falls back to broker leadership or direct Slack access.
+
 ## Using Pinet
 
 ### In Slack

--- a/slack-bridge/follower-runtime.ts
+++ b/slack-bridge/follower-runtime.ts
@@ -30,12 +30,8 @@ import {
   queueFollowerInboxIds,
   resetFollowerDeliveryState,
 } from "./follower-delivery.js";
-import { BrokerClient, DEFAULT_SOCKET_PATH } from "./broker/client.js";
-
-export function resolveBrokerSocketPath(): string {
-  const envPath = process.env.PINET_SOCKET_PATH?.trim();
-  return envPath && envPath.length > 0 ? envPath : DEFAULT_SOCKET_PATH;
-}
+import { BrokerClient } from "./broker/client.js";
+import { resolveFollowerBrokerSocketPath } from "./follower-socket.js";
 
 export type BrokerClientRef = {
   client: BrokerClient;
@@ -211,7 +207,7 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
     deps.refreshSettings();
     const meshAuth = resolvePinetMeshAuth(deps.getSettings());
     const client = new BrokerClient({
-      path: resolveBrokerSocketPath(),
+      path: resolveFollowerBrokerSocketPath(),
       ...(meshAuth.meshSecret ? { meshSecret: meshAuth.meshSecret } : {}),
       ...(meshAuth.meshSecretPath ? { meshSecretPath: meshAuth.meshSecretPath } : {}),
     });

--- a/slack-bridge/follower-socket.test.ts
+++ b/slack-bridge/follower-socket.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SOCKET_PATH } from "./broker/client.js";
+import { resolveFollowerBrokerSocketPath } from "./follower-socket.js";
+
+describe("resolveFollowerBrokerSocketPath", () => {
+  it("uses the default broker socket when no process override is configured", () => {
+    expect(resolveFollowerBrokerSocketPath({})).toBe(DEFAULT_SOCKET_PATH);
+    expect(resolveFollowerBrokerSocketPath({ PINET_SOCKET_PATH: "   " })).toBe(DEFAULT_SOCKET_PATH);
+  });
+
+  it("normalizes the process-scoped broker socket override", () => {
+    expect(
+      resolveFollowerBrokerSocketPath({ PINET_SOCKET_PATH: "  /tmp/pinet-custom.sock  " }),
+    ).toBe("/tmp/pinet-custom.sock");
+  });
+});

--- a/slack-bridge/follower-socket.ts
+++ b/slack-bridge/follower-socket.ts
@@ -1,0 +1,8 @@
+import { DEFAULT_SOCKET_PATH } from "./broker/client.js";
+
+export function resolveFollowerBrokerSocketPath(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): string {
+  const configuredPath = env.PINET_SOCKET_PATH?.trim();
+  return configuredPath && configuredPath.length > 0 ? configuredPath : DEFAULT_SOCKET_PATH;
+}

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -26,6 +26,13 @@ type CommandDefinition = {
 type EventHandler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
 
 function slackBridge(pi: ExtensionAPI, onActiveToolsChanged?: (toolNames: string[]) => void): void {
+  if (typeof pi.registerFlag !== "function") {
+    pi.registerFlag = vi.fn();
+  }
+  if (typeof pi.getFlag !== "function") {
+    pi.getFlag = vi.fn(() => undefined);
+  }
+
   const activeTools = new Set([
     "read",
     "slack",
@@ -1190,7 +1197,7 @@ describe("slack-bridge top-level shutdown", () => {
     await sessionShutdown?.({}, ctx);
   });
 
-  it("does not auto-follow into the mesh for headless ephemeral subagent sessions", async () => {
+  it("keeps the local-subagent gate above a process-scoped follow request", async () => {
     const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
     fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
     fs.writeFileSync(settingsPath, JSON.stringify({ "slack-bridge": { autoFollow: true } }));
@@ -1198,6 +1205,7 @@ describe("slack-bridge top-level shutdown", () => {
     const events = new Map<string, EventHandler>();
     const pi = {
       appendEntry: vi.fn(),
+      getFlag: vi.fn((name: string) => name === "pinet-follow"),
       registerTool: vi.fn(),
       registerCommand: vi.fn(),
       on: vi.fn((eventName: string, handler: EventHandler) => {

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -21,6 +21,7 @@ import {
 import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { resolveReactionCommands } from "./reaction-triggers.js";
+import { resolveFollowerBrokerSocketPath } from "./follower-socket.js";
 import {
   inspectBrokerLock,
   probeBrokerSocket,
@@ -63,11 +64,7 @@ import {
   markFollowerInboxIdsDelivered,
   queueFollowerInboxIds,
 } from "./follower-delivery.js";
-import {
-  createFollowerRuntime,
-  resolveBrokerSocketPath,
-  type BrokerClientRef,
-} from "./follower-runtime.js";
+import { createFollowerRuntime, type BrokerClientRef } from "./follower-runtime.js";
 import {
   createSinglePlayerRuntime,
   type SinglePlayerPendingAttentionEntry,
@@ -130,12 +127,18 @@ import {
 // Settings and helpers imported from ./helpers.js
 
 export default function (pi: ExtensionAPI) {
+  pi.registerFlag("pinet-follow", {
+    description: "Start this process as a Pinet follower without changing persistent settings",
+    type: "boolean",
+  });
+
   let settings = loadSettingsFromFile();
 
   let botToken = settings.botToken ?? process.env.SLACK_BOT_TOKEN;
   let appToken = settings.appToken ?? process.env.SLACK_APP_TOKEN;
+  const initialProcessFollowRequested = pi.getFlag("pinet-follow") === true;
 
-  if (!botToken || !appToken) return;
+  if (!initialProcessFollowRequested && (!botToken || !appToken)) return;
 
   const slackRequestRuntime = createSlackRequestRuntime();
   const { slack } = slackRequestRuntime;
@@ -1858,13 +1861,47 @@ export default function (pi: ExtensionAPI) {
 
     refreshSettings();
     maybeWarnSlackUserAccess(ctx);
+    const processFollowRequested = pi.getFlag("pinet-follow") === true;
+    const brokerSocketPath = resolveFollowerBrokerSocketPath();
+    const brokerSocketExists = fs.existsSync(brokerSocketPath);
     const startupMode = resolveSlackBridgeStartupRuntimeMode(settings, {
-      brokerSocketExists: fs.existsSync(resolveBrokerSocketPath()),
+      brokerSocketExists,
       brokerManagedFollowerLaunch: isBrokerManagedFollowerLaunch(),
+      processFollowRequested,
     });
+
+    if (processFollowRequested && !brokerSocketExists) {
+      const failure = `--pinet-follow could not find a broker socket at ${brokerSocketPath}. Continuing with Slack/Pinet/iMessage communication tools off. Start the broker or correct PINET_SOCKET_PATH, then restart this process.`;
+      console.error(`[slack-bridge] ${failure}`);
+      ctx.ui.notify(failure, "warning");
+    }
 
     if (startupMode === "off") {
       await transitionToRuntimeMode(ctx, startupMode);
+      return;
+    }
+
+    if (processFollowRequested) {
+      await toolRegistrationRuntime.sync(pi, "off");
+      setExtStatus(ctx, "reconnecting");
+      try {
+        await transitionToRuntimeMode(ctx, startupMode);
+        if (startupMode === "single") {
+          maybeWarnSlackGuardrailPosture(ctx);
+        }
+        console.log(`[slack-bridge] runtime mode: ${startupMode}`);
+      } catch (error) {
+        const failure = `--pinet-follow failed to connect and register with the broker at ${brokerSocketPath}: ${msg(error)}. Continuing with Slack/Pinet/iMessage communication tools off. Verify the broker, mesh authentication, and PINET_SOCKET_PATH, then restart this process.`;
+        console.error(`[slack-bridge] ${failure}`);
+        ctx.ui.notify(failure, "warning");
+        await runPinetLifecycle(() => stopPinetRuntime(ctx, { releaseIdentity: true })).catch(
+          (cleanupError) => {
+            console.error(`[slack-bridge] runtime cleanup failed: ${msg(cleanupError)}`);
+          },
+        );
+        slackRequestRuntime.reset();
+        singlePlayerRuntime.resetShutdownState();
+      }
       return;
     }
 

--- a/slack-bridge/process-follow-startup.test.ts
+++ b/slack-bridge/process-follow-startup.test.ts
@@ -1,0 +1,256 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { BrokerClient } from "./broker/client.js";
+import * as brokerModule from "./broker/index.js";
+import slackBridgeExtension from "./index.js";
+
+type ExtensionEventHandler = Parameters<ExtensionAPI["on"]>[1];
+
+function createStartupHarness() {
+  const events = new Map<string, ExtensionEventHandler>();
+  const activeTools = new Set([
+    "read",
+    "slack",
+    "slack_inbox",
+    "slack_send",
+    "pinet",
+    "imessage_send",
+  ]);
+  const registerFlag = vi.fn();
+  const setActiveTools = vi.fn((toolNames: string[]) => {
+    activeTools.clear();
+    for (const toolName of toolNames) activeTools.add(toolName);
+  });
+  const pi: ExtensionAPI = {
+    on: vi.fn((eventName, handler) => {
+      events.set(eventName, handler);
+    }),
+    registerTool: vi.fn(),
+    registerCommand: vi.fn(),
+    registerFlag,
+    getFlag: vi.fn((name) => name === "pinet-follow"),
+    registerMessageRenderer: vi.fn(),
+    sendUserMessage: vi.fn(),
+    sendMessage: vi.fn(),
+    appendEntry: vi.fn(),
+    getActiveTools: vi.fn(() => [...activeTools]),
+    setActiveTools,
+  };
+  const notify = vi.fn();
+  const setStatus = vi.fn();
+  const ctx: ExtensionContext = {
+    cwd: process.cwd(),
+    hasUI: false,
+    isIdle: () => true,
+    ui: {
+      theme: {
+        fg: (_color: string, text: string) => text,
+      },
+      notify,
+      setStatus,
+    },
+    sessionManager: {
+      getEntries: () => [],
+      getBranch: () => [],
+      getLeafId: () => "process-follow-leaf",
+      getSessionFile: () => "/tmp/process-follow-session.json",
+    },
+  };
+
+  return { activeTools, ctx, events, notify, pi, registerFlag, setStatus };
+}
+
+function restoreEnvironmentValue(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+function requireEvent(
+  events: ReadonlyMap<string, ExtensionEventHandler>,
+  eventName: string,
+): ExtensionEventHandler {
+  const handler = events.get(eventName);
+  if (!handler) throw new Error(`Missing ${eventName} handler`);
+  return handler;
+}
+
+function stubFollowerClient(registration: "success" | "failure") {
+  const connect = vi.spyOn(BrokerClient.prototype, "connect").mockResolvedValue(undefined);
+  const register = vi.spyOn(BrokerClient.prototype, "register").mockImplementation(async () => {
+    if (registration === "failure") {
+      throw new Error("mesh authentication rejected");
+    }
+    return {
+      agentId: "process-follower",
+      name: "Process Follower",
+      emoji: "🐻",
+      metadata: null,
+    };
+  });
+  vi.spyOn(BrokerClient.prototype, "isConnected").mockReturnValue(true);
+  vi.spyOn(BrokerClient.prototype, "claimThread").mockResolvedValue({ claimed: true });
+  vi.spyOn(BrokerClient.prototype, "pollInbox").mockResolvedValue([]);
+  vi.spyOn(BrokerClient.prototype, "updateStatus").mockResolvedValue(undefined);
+  vi.spyOn(BrokerClient.prototype, "ackMessages").mockResolvedValue(undefined);
+  vi.spyOn(BrokerClient.prototype, "disconnectGracefully").mockResolvedValue(undefined);
+  vi.spyOn(BrokerClient.prototype, "unregister").mockResolvedValue(undefined);
+  vi.spyOn(BrokerClient.prototype, "disconnect").mockImplementation(() => {});
+  vi.spyOn(BrokerClient.prototype, "onDisconnect").mockImplementation(() => {});
+  vi.spyOn(BrokerClient.prototype, "onReconnect").mockImplementation(() => {});
+  vi.spyOn(BrokerClient.prototype, "onReconnectFailed").mockImplementation(() => {});
+
+  return { connect, register };
+}
+
+describe("--pinet-follow process startup", () => {
+  const originalHome = process.env.HOME;
+  const originalBotToken = process.env.SLACK_BOT_TOKEN;
+  const originalAppToken = process.env.SLACK_APP_TOKEN;
+  const originalSocketPath = process.env.PINET_SOCKET_PATH;
+  let testHome: string;
+
+  beforeEach(() => {
+    testHome = fs.mkdtempSync(path.join(os.tmpdir(), "pinet-follow-startup-"));
+    process.env.HOME = testHome;
+    process.env.SLACK_BOT_TOKEN = "xoxb-test";
+    process.env.SLACK_APP_TOKEN = "xapp-test";
+    delete process.env.PINET_SOCKET_PATH;
+    fs.mkdirSync(path.join(testHome, ".pi", "agent"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(testHome, { recursive: true, force: true });
+    vi.restoreAllMocks();
+
+    restoreEnvironmentValue("HOME", originalHome);
+    restoreEnvironmentValue("SLACK_BOT_TOKEN", originalBotToken);
+    restoreEnvironmentValue("SLACK_APP_TOKEN", originalAppToken);
+    restoreEnvironmentValue("PINET_SOCKET_PATH", originalSocketPath);
+  });
+
+  it("overrides persistent broker mode, registers as follower, and activates brokered tools", async () => {
+    const settingsPath = path.join(testHome, ".pi", "agent", "settings.json");
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({ "slack-bridge": { runtimeMode: "broker", allowAllWorkspaceUsers: true } }),
+    );
+    const customSocketPath = path.join(testHome, "broker", "pinet.sock");
+    fs.mkdirSync(path.dirname(customSocketPath), { recursive: true });
+    fs.writeFileSync(customSocketPath, "");
+    process.env.PINET_SOCKET_PATH = customSocketPath;
+
+    const follower = stubFollowerClient("success");
+    const startBroker = vi.spyOn(brokerModule, "startBroker");
+    const harness = createStartupHarness();
+
+    slackBridgeExtension(harness.pi);
+    await requireEvent(harness.events, "session_start")({}, harness.ctx);
+
+    expect(harness.registerFlag).toHaveBeenCalledWith("pinet-follow", {
+      description: expect.stringContaining("without changing persistent settings"),
+      type: "boolean",
+    });
+    expect(follower.connect).toHaveBeenCalledOnce();
+    expect(follower.register).toHaveBeenCalledOnce();
+    expect(startBroker).not.toHaveBeenCalled();
+    expect(harness.activeTools).toEqual(
+      new Set(["read", "slack", "slack_inbox", "slack_send", "pinet", "imessage_send"]),
+    );
+    expect(JSON.parse(fs.readFileSync(settingsPath, "utf8"))).toEqual({
+      "slack-bridge": { runtimeMode: "broker", allowAllWorkspaceUsers: true },
+    });
+
+    await requireEvent(harness.events, "session_shutdown")({}, harness.ctx);
+  });
+
+  it("does not require local Slack tokens before connecting to the broker as a process follower", async () => {
+    delete process.env.SLACK_BOT_TOKEN;
+    delete process.env.SLACK_APP_TOKEN;
+    fs.writeFileSync(
+      path.join(testHome, ".pi", "agent", "settings.json"),
+      JSON.stringify({ "slack-bridge": { runtimeMode: "broker", allowAllWorkspaceUsers: true } }),
+    );
+    const customSocketPath = path.join(testHome, "broker", "pinet.sock");
+    fs.mkdirSync(path.dirname(customSocketPath), { recursive: true });
+    fs.writeFileSync(customSocketPath, "");
+    process.env.PINET_SOCKET_PATH = customSocketPath;
+
+    const follower = stubFollowerClient("success");
+    const startBroker = vi.spyOn(brokerModule, "startBroker");
+    const harness = createStartupHarness();
+
+    slackBridgeExtension(harness.pi);
+    await requireEvent(harness.events, "session_start")({}, harness.ctx);
+
+    expect(follower.connect).toHaveBeenCalledOnce();
+    expect(follower.register).toHaveBeenCalledOnce();
+    expect(startBroker).not.toHaveBeenCalled();
+    expect(harness.activeTools).toEqual(
+      new Set(["read", "slack", "slack_inbox", "slack_send", "pinet", "imessage_send"]),
+    );
+
+    await requireEvent(harness.events, "session_shutdown")({}, harness.ctx);
+  });
+
+  it("stays visibly off without a broker socket and never attempts broker or Slack access", async () => {
+    fs.writeFileSync(
+      path.join(testHome, ".pi", "agent", "settings.json"),
+      JSON.stringify({ "slack-bridge": { runtimeMode: "broker", allowAllWorkspaceUsers: true } }),
+    );
+    const missingSocketPath = path.join(testHome, "missing", "pinet.sock");
+    process.env.PINET_SOCKET_PATH = missingSocketPath;
+
+    const connect = vi.spyOn(BrokerClient.prototype, "connect");
+    const startBroker = vi.spyOn(brokerModule, "startBroker");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const harness = createStartupHarness();
+
+    slackBridgeExtension(harness.pi);
+    await requireEvent(harness.events, "session_start")({}, harness.ctx);
+
+    expect(connect).not.toHaveBeenCalled();
+    expect(startBroker).not.toHaveBeenCalled();
+    expect(harness.activeTools).toEqual(new Set(["read"]));
+    expect(harness.notify).toHaveBeenCalledWith(
+      expect.stringContaining(`could not find a broker socket at ${missingSocketPath}`),
+      "warning",
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Continuing with Slack/Pinet/iMessage communication tools off"),
+    );
+  });
+
+  it("stays visibly off when broker authentication or registration fails", async () => {
+    fs.writeFileSync(
+      path.join(testHome, ".pi", "agent", "settings.json"),
+      JSON.stringify({ "slack-bridge": { runtimeMode: "single", allowAllWorkspaceUsers: true } }),
+    );
+    const customSocketPath = path.join(testHome, "broker", "pinet.sock");
+    fs.mkdirSync(path.dirname(customSocketPath), { recursive: true });
+    fs.writeFileSync(customSocketPath, "");
+    process.env.PINET_SOCKET_PATH = customSocketPath;
+
+    const follower = stubFollowerClient("failure");
+    const startBroker = vi.spyOn(brokerModule, "startBroker");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const harness = createStartupHarness();
+
+    slackBridgeExtension(harness.pi);
+    await requireEvent(harness.events, "session_start")({}, harness.ctx);
+
+    expect(follower.connect).toHaveBeenCalledOnce();
+    expect(follower.register).toHaveBeenCalledOnce();
+    expect(startBroker).not.toHaveBeenCalled();
+    expect(harness.activeTools).toEqual(new Set(["read"]));
+    expect(harness.notify).toHaveBeenCalledWith(
+      expect.stringContaining("mesh authentication rejected"),
+      "warning",
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Verify the broker, mesh authentication, and PINET_SOCKET_PATH"),
+    );
+  });
+});

--- a/slack-bridge/runtime-mode.test.ts
+++ b/slack-bridge/runtime-mode.test.ts
@@ -127,6 +127,41 @@ describe("resolveSlackBridgeStartupRuntimeMode", () => {
     expect(resolveSlackBridgeStartupRuntimeMode({ runtimeMode: "broker" })).toBe("broker");
   });
 
+  it("lets a process-scoped follow request override persistent modes without mutating settings", () => {
+    for (const runtimeMode of ["off", "single", "broker"] as const) {
+      const settings = { runtimeMode };
+      expect(
+        resolveSlackBridgeStartupRuntimeMode(settings, {
+          brokerSocketExists: true,
+          processFollowRequested: true,
+        }),
+      ).toBe("follower");
+      expect(settings.runtimeMode).toBe(runtimeMode);
+    }
+  });
+
+  it("keeps a process-scoped follow request off when its broker socket is unavailable", () => {
+    expect(
+      resolveSlackBridgeStartupRuntimeMode(
+        { runtimeMode: "broker" },
+        { brokerSocketExists: false, processFollowRequested: true },
+      ),
+    ).toBe("off");
+  });
+
+  it("honors an explicit process follow request for broker-managed launches", () => {
+    expect(
+      resolveSlackBridgeStartupRuntimeMode(
+        { runtimeMode: "broker" },
+        {
+          brokerSocketExists: true,
+          brokerManagedFollowerLaunch: true,
+          processFollowRequested: true,
+        },
+      ),
+    ).toBe("follower");
+  });
+
   it("keeps broker-managed follower launches off even when persistent settings request broker mode", () => {
     expect(
       resolveSlackBridgeStartupRuntimeMode(

--- a/slack-bridge/runtime-mode.ts
+++ b/slack-bridge/runtime-mode.ts
@@ -24,6 +24,7 @@ export function isPinetRuntimeMode(mode: SlackBridgeRuntimeMode): boolean {
 export interface ResolveSlackBridgeStartupRuntimeModeOptions {
   brokerSocketExists?: boolean;
   brokerManagedFollowerLaunch?: boolean;
+  processFollowRequested?: boolean;
 }
 
 export function isBrokerManagedFollowerLaunch(env = process.env): boolean {
@@ -41,6 +42,10 @@ export function resolveSlackBridgeStartupRuntimeMode(
 ): SlackBridgeRuntimeMode {
   const explicitMode = normalizeSlackBridgeRuntimeMode(settings.runtimeMode);
   const brokerSocketExists = options.brokerSocketExists ?? true;
+
+  if (options.processFollowRequested) {
+    return brokerSocketExists ? "follower" : "off";
+  }
 
   if (options.brokerManagedFollowerLaunch) {
     if (explicitMode === "follower" || (!explicitMode && settings.autoFollow)) {

--- a/slack-bridge/tool-registration-runtime.test.ts
+++ b/slack-bridge/tool-registration-runtime.test.ts
@@ -83,6 +83,8 @@ describe("createToolRegistrationRuntime", () => {
       on: vi.fn(),
       registerTool: vi.fn(),
       registerCommand: vi.fn(),
+      registerFlag: vi.fn(),
+      getFlag: vi.fn(() => undefined),
       registerMessageRenderer: vi.fn(),
       sendUserMessage: vi.fn(),
       sendMessage: vi.fn(),

--- a/types/pi-coding-agent.d.ts
+++ b/types/pi-coding-agent.d.ts
@@ -87,6 +87,11 @@ declare module "@earendil-works/pi-coding-agent" {
     on(event: string, handler: (event: any, ctx: ExtensionContext) => any): void;
     registerTool(definition: ToolDefinition): void;
     registerCommand(name: string, options: CommandDefinition): void;
+    registerFlag(
+      name: string,
+      options: { description?: string; type: "boolean" | "string"; default?: boolean | string },
+    ): void;
+    getFlag(name: string): boolean | string | undefined;
     registerMessageRenderer(
       name: string,
       renderer: (message: any, options: any, theme: any) => any,


### PR DESCRIPTION
## Summary

- add the process-scoped `--pinet-follow` extension flag without persisting settings
- resolve the startup socket and follower client socket through one `PINET_SOCKET_PATH`-aware helper
- keep unavailable socket, authentication, and registration failures visibly fail-closed with communication tools off
- preserve the local-subagent gate, mesh authentication, follower identity, and broker-owned thread routing
- document headless and launchd usage

Fixes #982.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @pinet/slack-bridge build`
- `pnpm exec vitest run slack-bridge/runtime-mode.test.ts slack-bridge/follower-socket.test.ts slack-bridge/process-follow-startup.test.ts slack-bridge/tool-registration-runtime.test.ts slack-bridge/index.test.ts` (68 passed)
- `pnpm --filter @pinet/slack-bridge test` with a transient URL rewrite from the checkout's pre-rename `gugu91/extensions` remote to `gugu91/pinet` (1703 passed, 3 skipped)
- repository local code-reviewer: no findings

The unmodified local remote still uses the repository's former `gugu91/extensions` URL. Without the transient rewrite, one pre-existing repo-identity assertion expects `pinet` but receives `extensions`; no repository config or unrelated test was changed.
