### PR TITLE
Speed up Slack bridge startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@10.18.1",
   "pi": {
     "extensions": [
-      "./slack-bridge/index.ts",
+      "./slack-bridge/dist/index.js",
       "./nvim-bridge/index.ts",
       "./neon-psql/index.ts"
     ]

--- a/scripts/build-all.test.mjs
+++ b/scripts/build-all.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { buildTiers, flattenBuildTiers, testDependencyTiers } from "./build-all.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 const expectedBuildPackages = [
   "transport-core",
@@ -46,6 +51,13 @@ test("test dependency tiers cover only the dist exports needed before tests", ()
     "imessage-bridge": ["transport-core"],
     "pinet-core": ["broker-core", "transport-core"],
   });
+});
+
+test("the root Pi manifest loads the built Slack bridge", async () => {
+  const manifest = JSON.parse(await readFile(path.join(repoRoot, "package.json"), "utf8"));
+
+  assert.ok(manifest.pi.extensions.includes("./slack-bridge/dist/index.js"));
+  assert.ok(!manifest.pi.extensions.includes("./slack-bridge/index.ts"));
 });
 
 function assertTierDependencies(tiers, dependenciesByPackage) {

--- a/scripts/build-all.test.mjs
+++ b/scripts/build-all.test.mjs
@@ -57,7 +57,6 @@ test("the root Pi manifest loads the built Slack bridge", async () => {
   const manifest = JSON.parse(await readFile(path.join(repoRoot, "package.json"), "utf8"));
 
   assert.ok(manifest.pi.extensions.includes("./slack-bridge/dist/index.js"));
-  assert.ok(!manifest.pi.extensions.includes("./slack-bridge/index.ts"));
 });
 
 function assertTierDependencies(tiers, dependenciesByPackage) {

--- a/slack-bridge/broker-runtime.test.ts
+++ b/slack-bridge/broker-runtime.test.ts
@@ -92,9 +92,7 @@ describe("broker-runtime", () => {
             rejectConnect = reject;
           }),
       ),
-      disconnect: vi.fn(async () => {
-        rejectConnect(new Error("adapter startup aborted"));
-      }),
+      disconnect: vi.fn(async () => undefined),
       onInbound: vi.fn(),
       send: vi.fn(async () => undefined),
     } satisfies MessageAdapter;
@@ -151,9 +149,12 @@ describe("broker-runtime", () => {
         expect(adapter.connect).toHaveBeenCalledOnce();
       });
       controller.abort();
+      await vi.waitFor(() => {
+        expect(adapter.disconnect).toHaveBeenCalledOnce();
+      });
+      rejectConnect(new Error("adapter startup failed"));
 
-      await expect(connecting).rejects.toThrow("adapter startup aborted");
-      expect(adapter.disconnect).toHaveBeenCalledOnce();
+      await expect(connecting).rejects.toThrow("adapter startup failed");
       expect(db.unregisterAgent).toHaveBeenCalledWith("broker-self");
       expect(stop).toHaveBeenCalledOnce();
       expect(runtime.isConnected()).toBe(false);

--- a/slack-bridge/broker-runtime.test.ts
+++ b/slack-bridge/broker-runtime.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { BrokerControlPlaneDashboardSnapshot } from "./broker/control-plane-dashboard.js";
 import {
   createBrokerRuntime,
@@ -6,6 +7,8 @@ import {
   type BrokerRuntimeDeps,
 } from "./broker-runtime.js";
 import type { SlackActivityLogger } from "./activity-log.js";
+import type { MessageAdapter } from "./broker/types.js";
+import * as brokerModule from "./broker/index.js";
 
 function createDeps(overrides: Partial<BrokerRuntimeDeps> = {}): BrokerRuntimeDeps {
   return {
@@ -77,6 +80,86 @@ describe("broker-runtime", () => {
     expect(resolveConfiguredBrokerSkinTheme({ skinTheme: "foundation" })).toBe("foundation");
     expect(resolveConfiguredBrokerSkinTheme({ skinTheme: "classic" })).toBe("default");
     expect(resolveConfiguredBrokerSkinTheme({})).toBe("default");
+  });
+
+  it("tears down a broker whose adapter connection is aborted", async () => {
+    let rejectConnect!: (error: Error) => void;
+    const adapter = {
+      name: "hanging-adapter",
+      connect: vi.fn(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectConnect = reject;
+          }),
+      ),
+      disconnect: vi.fn(async () => {
+        rejectConnect(new Error("adapter startup aborted"));
+      }),
+      onInbound: vi.fn(),
+      send: vi.fn(async () => undefined),
+    } satisfies MessageAdapter;
+    const adapters: MessageAdapter[] = [];
+    const db = {
+      setAllowedUsers: vi.fn(),
+      getSetting: vi.fn(() => null),
+      getAllAgents: vi.fn(() => []),
+      setSetting: vi.fn(),
+      registerAgent: vi.fn(() => ({
+        id: "broker-self",
+        name: "Cobalt Olive Crane",
+        emoji: "🪶",
+      })),
+      unregisterAgent: vi.fn(),
+      releaseThreadClaims: vi.fn(() => 0),
+      recoverPendingTargetedBacklog: vi.fn(() => 0),
+      getPendingInboxCount: vi.fn(() => 0),
+      getInbox: vi.fn(() => []),
+    };
+    const stop = vi.fn(async () => undefined);
+    const startBroker = vi.spyOn(brokerModule, "startBroker").mockResolvedValue({
+      db,
+      server: {
+        setAgentRegistrationResolver: vi.fn(),
+        onAgentMessage: vi.fn(),
+        onAgentStatusChange: vi.fn(),
+        setAdminShutdownHandler: vi.fn(),
+      },
+      lock: { isLeader: () => true, release: vi.fn() },
+      adapters,
+      addAdapter: (nextAdapter: MessageAdapter) => {
+        adapters.push(nextAdapter);
+      },
+      removeAdapters: vi.fn(async () => undefined),
+      stop,
+    } as never);
+    const runtime = createBrokerRuntime(
+      createDeps({
+        createAdapterBindings: [() => ({ adapter })],
+      }),
+    );
+    const ctx = {
+      sessionManager: {
+        getLeafId: () => "broker-startup-leaf",
+      },
+      ui: { notify: vi.fn() },
+    } as never as ExtensionContext;
+    const controller = new AbortController();
+
+    try {
+      const connecting = runtime.connect(ctx, controller.signal);
+      await vi.waitFor(() => {
+        expect(adapter.connect).toHaveBeenCalledOnce();
+      });
+      controller.abort();
+
+      await expect(connecting).rejects.toThrow("adapter startup aborted");
+      expect(adapter.disconnect).toHaveBeenCalledOnce();
+      expect(db.unregisterAgent).toHaveBeenCalledWith("broker-self");
+      expect(stop).toHaveBeenCalledOnce();
+      expect(runtime.isConnected()).toBe(false);
+    } finally {
+      startBroker.mockRestore();
+    }
   });
 
   it("clears transient Home tab observability state on disconnect", async () => {

--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -74,7 +74,10 @@ export interface BrokerRuntimeDeps {
   getActiveSkinTheme: () => string | null;
   setActiveSkinTheme: (theme: string) => void;
   setAgentOwnerToken: (ownerToken: string) => void;
-  getAgentMetadata: (role: "broker" | "worker") => Promise<Record<string, unknown>>;
+  getAgentMetadata: (
+    role: "broker" | "worker",
+    signal?: AbortSignal,
+  ) => Promise<Record<string, unknown>>;
   applyLocalAgentIdentity: (name: string, emoji: string, personality: string | null) => void;
   buildSkinMetadata: (
     metadata: Record<string, unknown> | undefined,
@@ -177,7 +180,7 @@ export function resolveConfiguredBrokerSkinTheme(settings: SlackBridgeSettings):
 }
 
 export interface BrokerRuntime {
-  connect: (ctx: ExtensionContext) => Promise<BrokerRuntimeConnectResult>;
+  connect: (ctx: ExtensionContext, signal?: AbortSignal) => Promise<BrokerRuntimeConnectResult>;
   reloadAdapters: (ctx: ExtensionContext) => Promise<{ botUserId: string | null }>;
   canReloadInPlace: () => boolean;
   disconnect: (options?: { releaseIdentity?: boolean }) => Promise<void>;
@@ -560,7 +563,11 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
   }
 
   return {
-    async connect(ctx: ExtensionContext): Promise<BrokerRuntimeConnectResult> {
+    async connect(
+      ctx: ExtensionContext,
+      signal?: AbortSignal,
+    ): Promise<BrokerRuntimeConnectResult> {
+      signal?.throwIfAborted();
       const settings = deps.getSettings();
       const meshAuth = resolvePinetMeshAuth(settings);
       const allowedUsers = deps.getAllowedUsers();
@@ -572,6 +579,7 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
       activityLogContext = ctx;
 
       try {
+        signal?.throwIfAborted();
         broker.db.setAllowedUsers(allowedUsers);
         const router = new MessageRouter(broker.db);
         const persistedBrokerStableId =
@@ -630,19 +638,22 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
           role: "broker",
           seed: brokerStableId,
         });
+        const agentMetadata = await deps.getAgentMetadata("broker", signal);
+        signal?.throwIfAborted();
         const selfAgent = broker.db.registerAgent(
           ctx.sessionManager.getLeafId() ?? `broker-${process.pid}`,
           selfAssignment.name,
           selfAssignment.emoji,
           process.pid,
           deps.buildSkinMetadata(
-            await deps.getAgentMetadata("broker"),
+            agentMetadata,
             selfAssignment.personality,
             selfAssignment.statusVocabulary,
           ),
           brokerStableId,
         );
         selfId = selfAgent.id;
+        signal?.throwIfAborted();
         deps.applyLocalAgentIdentity(selfAgent.name, selfAgent.emoji, selfAssignment.personality);
 
         const brokerSelfId = selfId;
@@ -658,7 +669,9 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
           onInbound: (message) => {
             void deps.handleInboundMessage({ message, broker, router, selfId: brokerSelfId, ctx });
           },
+          signal,
         });
+        signal?.throwIfAborted();
 
         activeBroker = broker;
         activeRuntimeAdapters = adapterBindings.map((binding) => binding.adapter);

--- a/slack-bridge/broker-runtime.ts
+++ b/slack-bridge/broker-runtime.ts
@@ -653,7 +653,6 @@ export function createBrokerRuntime(deps: BrokerRuntimeDeps): BrokerRuntime {
           brokerStableId,
         );
         selfId = selfAgent.id;
-        signal?.throwIfAborted();
         deps.applyLocalAgentIdentity(selfAgent.name, selfAgent.emoji, selfAssignment.personality);
 
         const brokerSelfId = selfId;

--- a/slack-bridge/broker/client.test.ts
+++ b/slack-bridge/broker/client.test.ts
@@ -174,6 +174,16 @@ describe("BrokerClient — connect / disconnect", () => {
     expect(client.isConnected()).toBe(false);
   });
 
+  it("disconnect rejects a pending socket connection", async () => {
+    const client = new BrokerClient(mock.connectOpts);
+
+    const connecting = client.connect();
+    client.disconnect();
+
+    await expect(connecting).rejects.toThrow("Socket closed before connection completed");
+    expect(client.isConnected()).toBe(false);
+  });
+
   it("rejects connect when server is not running", async () => {
     const client = new BrokerClient({ host: "127.0.0.1", port: 1 });
     await expect(client.connect()).rejects.toThrow();

--- a/slack-bridge/broker/client.ts
+++ b/slack-bridge/broker/client.ts
@@ -252,6 +252,7 @@ export class BrokerClient {
   private readonly meshSecretPath: string | null;
   private readonly reconnectDelayMs: (attempt: number) => number;
   private socket: net.Socket | null = null;
+  private connectingSocket: net.Socket | null = null;
   private connected = false;
   private shuttingDown = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -326,7 +327,10 @@ export class BrokerClient {
     }
     this.stopHeartbeat();
     this.rejectAllPending(new Error("Client disconnected"));
+    const connectingSocket = this.connectingSocket;
+    this.connectingSocket = null;
     try {
+      connectingSocket?.destroy();
       this.socket?.destroy();
     } catch {
       /* ignore */
@@ -837,8 +841,28 @@ export class BrokerClient {
   private connectSocket(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       const sock = net.createConnection(this.connectOpts);
+      this.connectingSocket = sock;
+      let settled = false;
+
+      const rejectConnect = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        if (this.connectingSocket === sock) {
+          this.connectingSocket = null;
+        }
+        reject(error);
+      };
 
       sock.on("connect", () => {
+        if (this.shuttingDown) {
+          rejectConnect(new Error("Client disconnected while connecting"));
+          sock.destroy();
+          return;
+        }
+        settled = true;
+        if (this.connectingSocket === sock) {
+          this.connectingSocket = null;
+        }
         this.socket = sock;
         this.connected = true;
         this.buffer = "";
@@ -850,6 +874,12 @@ export class BrokerClient {
       });
 
       sock.on("close", () => {
+        if (this.connectingSocket === sock) {
+          this.connectingSocket = null;
+        }
+        if (!settled) {
+          rejectConnect(new Error("Socket closed before connection completed"));
+        }
         const wasConnected = this.connected;
         this.connected = false;
         this.socket = null;
@@ -862,8 +892,8 @@ export class BrokerClient {
       });
 
       sock.on("error", (err: Error) => {
-        if (!this.connected) {
-          reject(err);
+        if (!settled) {
+          rejectConnect(err);
         }
         // If already connected, the close event handles cleanup
       });

--- a/slack-bridge/follower-runtime.ts
+++ b/slack-bridge/follower-runtime.ts
@@ -32,7 +32,7 @@ import {
 } from "./follower-delivery.js";
 import { BrokerClient, DEFAULT_SOCKET_PATH } from "./broker/client.js";
 
-function resolveBrokerSocketPath(): string {
+export function resolveBrokerSocketPath(): string {
   const envPath = process.env.PINET_SOCKET_PATH?.trim();
   return envPath && envPath.length > 0 ? envPath : DEFAULT_SOCKET_PATH;
 }

--- a/slack-bridge/follower-runtime.ts
+++ b/slack-bridge/follower-runtime.ts
@@ -61,7 +61,10 @@ export interface FollowerRuntimeDeps {
   getLastDmChannel: () => string | null;
   setLastDmChannel: (channelId: string | null) => void;
   pushInboxMessages: (messages: InboxMessage[]) => void;
-  getAgentMetadata: (role: "broker" | "worker") => Promise<Record<string, unknown>>;
+  getAgentMetadata: (
+    role: "broker" | "worker",
+    signal?: AbortSignal,
+  ) => Promise<Record<string, unknown>>;
   applyRegistrationIdentity: (registration: {
     name: string;
     emoji: string;
@@ -88,7 +91,7 @@ export interface FollowerRuntimeDeps {
 }
 
 export interface FollowerRuntime {
-  connect: (ctx: ExtensionContext) => Promise<BrokerClientRef>;
+  connect: (ctx: ExtensionContext, signal?: AbortSignal) => Promise<BrokerClientRef>;
   disconnect: (
     ctx: ExtensionContext,
     options?: { releaseIdentity?: boolean },
@@ -203,7 +206,8 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
     resetFollowerDeliveryState(deps.deliveryState);
   }
 
-  async function connect(ctx: ExtensionContext): Promise<BrokerClientRef> {
+  async function connect(ctx: ExtensionContext, signal?: AbortSignal): Promise<BrokerClientRef> {
+    signal?.throwIfAborted();
     deps.refreshSettings();
     const meshAuth = resolvePinetMeshAuth(deps.getSettings());
     const client = new BrokerClient({
@@ -211,6 +215,10 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
       ...(meshAuth.meshSecret ? { meshSecret: meshAuth.meshSecret } : {}),
       ...(meshAuth.meshSecretPath ? { meshSecretPath: meshAuth.meshSecretPath } : {}),
     });
+    const abortConnect = () => {
+      client.disconnect();
+    };
+    signal?.addEventListener("abort", abortConnect, { once: true });
 
     async function registerFollowerRuntime(): Promise<void> {
       deps.refreshSettings();
@@ -231,7 +239,7 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
       const registration = await client.register(
         hasExplicitIdentityRequest ? workerIdentity.name : "",
         hasExplicitIdentityRequest ? workerIdentity.emoji : "",
-        await deps.getAgentMetadata("worker"),
+        await deps.getAgentMetadata("worker", signal),
         deps.getAgentStableId(),
       );
       deps.applyRegistrationIdentity(registration);
@@ -411,7 +419,9 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
 
     try {
       await client.connect();
+      signal?.throwIfAborted();
       await registerFollowerRuntime();
+      signal?.throwIfAborted();
       deps.setRuntimeDiagnostic(null);
 
       syncedFollowerStatus = "idle";
@@ -492,6 +502,7 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
       });
 
       await resumeThreadClaims();
+      signal?.throwIfAborted();
       startPolling();
       return clientRef;
     } catch (error) {
@@ -501,6 +512,8 @@ export function createFollowerRuntime(deps: FollowerRuntimeDeps): FollowerRuntim
       client.disconnect();
       resetFollowerRuntimeState();
       throw error;
+    } finally {
+      signal?.removeEventListener("abort", abortConnect);
     }
   }
 

--- a/slack-bridge/git-metadata.test.ts
+++ b/slack-bridge/git-metadata.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   createGitContextCache,
-  GIT_PROBE_TIMEOUT_MS,
   probeGitBranch,
   probeGitContext,
   probeGitDynamic,
@@ -25,16 +24,12 @@ describe("probeGitBranch", () => {
 });
 
 describe("probeGitContext", () => {
-  it("aborts an in-flight Git process and applies a fallback timeout", async () => {
+  it("aborts an in-flight Git process", async () => {
     const controller = new AbortController();
     const runner: ExecFileAsyncLike = vi.fn(
-      async (_file, _args, options) =>
+      async (_file, _args, { signal }) =>
         new Promise<never>((_resolve, reject) => {
-          expect(options.timeout).toBe(GIT_PROBE_TIMEOUT_MS);
-          expect(options.signal).toBe(controller.signal);
-          options.signal?.addEventListener("abort", () => reject(options.signal?.reason), {
-            once: true,
-          });
+          signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
         }),
     );
 
@@ -211,26 +206,6 @@ describe("createGitContextCache", () => {
 
     await expect(a).resolves.toMatchObject({ repo: "project" });
     await expect(b).resolves.toMatchObject({ repo: "project" });
-  });
-
-  it("lets an aborted waiter stop waiting on a shared in-flight probe", async () => {
-    let resolveLoader!: (value: { cwd: string; repo: string }) => void;
-    const loader = vi.fn(
-      () =>
-        new Promise<{ cwd: string; repo: string }>((resolve) => {
-          resolveLoader = resolve;
-        }),
-    );
-    const cache = createGitContextCache(loader);
-    const shared = cache.get();
-    const controller = new AbortController();
-    const cancelled = cache.get(controller.signal);
-
-    controller.abort();
-    await expect(cancelled).rejects.toMatchObject({ name: "AbortError" });
-
-    resolveLoader({ cwd: "/tmp/project", repo: "project" });
-    await expect(shared).resolves.toMatchObject({ repo: "project" });
   });
 
   it("clear resets the cache", async () => {

--- a/slack-bridge/git-metadata.test.ts
+++ b/slack-bridge/git-metadata.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   createGitContextCache,
+  GIT_PROBE_TIMEOUT_MS,
   probeGitBranch,
   probeGitContext,
   probeGitDynamic,
@@ -24,6 +25,25 @@ describe("probeGitBranch", () => {
 });
 
 describe("probeGitContext", () => {
+  it("aborts an in-flight Git process and applies a fallback timeout", async () => {
+    const controller = new AbortController();
+    const runner: ExecFileAsyncLike = vi.fn(
+      async (_file, _args, options) =>
+        new Promise<never>((_resolve, reject) => {
+          expect(options.timeout).toBe(GIT_PROBE_TIMEOUT_MS);
+          expect(options.signal).toBe(controller.signal);
+          options.signal?.addEventListener("abort", () => reject(options.signal?.reason), {
+            once: true,
+          });
+        }),
+    );
+
+    const probing = probeGitContext("/tmp/project", runner, controller.signal);
+    controller.abort();
+
+    await expect(probing).rejects.toMatchObject({ name: "AbortError" });
+  });
+
   it("returns repo, repoRoot, branch, and dirty signal when git commands succeed", async () => {
     const runner: ExecFileAsyncLike = vi.fn(async (_file, args) => {
       if (args[0] === "rev-parse") {
@@ -191,6 +211,26 @@ describe("createGitContextCache", () => {
 
     await expect(a).resolves.toMatchObject({ repo: "project" });
     await expect(b).resolves.toMatchObject({ repo: "project" });
+  });
+
+  it("lets an aborted waiter stop waiting on a shared in-flight probe", async () => {
+    let resolveLoader!: (value: { cwd: string; repo: string }) => void;
+    const loader = vi.fn(
+      () =>
+        new Promise<{ cwd: string; repo: string }>((resolve) => {
+          resolveLoader = resolve;
+        }),
+    );
+    const cache = createGitContextCache(loader);
+    const shared = cache.get();
+    const controller = new AbortController();
+    const cancelled = cache.get(controller.signal);
+
+    controller.abort();
+    await expect(cancelled).rejects.toMatchObject({ name: "AbortError" });
+
+    resolveLoader({ cwd: "/tmp/project", repo: "project" });
+    await expect(shared).resolves.toMatchObject({ repo: "project" });
   });
 
   it("clear resets the cache", async () => {

--- a/slack-bridge/git-metadata.ts
+++ b/slack-bridge/git-metadata.ts
@@ -5,7 +5,7 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 type ExecFileResult = { stdout?: string | Buffer };
-export const GIT_PROBE_TIMEOUT_MS = 2_000;
+const GIT_PROBE_TIMEOUT_MS = 2_000;
 
 export type ExecFileAsyncLike = (
   file: string,
@@ -50,7 +50,7 @@ async function runGitCommand(
       cwd,
       encoding: "utf-8",
       timeout: GIT_PROBE_TIMEOUT_MS,
-      ...(signal ? { signal } : {}),
+      signal,
     });
     const stdout = typeof result.stdout === "string" ? result.stdout : result.stdout?.toString();
     return { stdout, ok: true };
@@ -147,6 +147,7 @@ export interface GitContextCache {
   clear(): void;
 }
 
+// agent-standards-ignore prefer-inline-single-use-helper: isolates abortable waiting from the shared cache load
 function waitForGitContext(
   promise: Promise<GitContext>,
   signal?: AbortSignal,
@@ -154,21 +155,9 @@ function waitForGitContext(
   if (!signal) return promise;
   signal.throwIfAborted();
   return new Promise((resolve, reject) => {
-    const abort = () => {
-      signal.removeEventListener("abort", abort);
-      reject(signal.reason);
-    };
+    const abort = () => reject(signal.reason);
     signal.addEventListener("abort", abort, { once: true });
-    promise.then(
-      (value) => {
-        signal.removeEventListener("abort", abort);
-        resolve(value);
-      },
-      (error) => {
-        signal.removeEventListener("abort", abort);
-        reject(error);
-      },
-    );
+    promise.finally(() => signal.removeEventListener("abort", abort)).then(resolve, reject);
   });
 }
 
@@ -180,7 +169,6 @@ export function createGitContextCache(
 
   return {
     async get(signal?: AbortSignal): Promise<GitContext> {
-      signal?.throwIfAborted();
       if (cached) return cached;
       if (inflight) return waitForGitContext(inflight, signal);
 

--- a/slack-bridge/git-metadata.ts
+++ b/slack-bridge/git-metadata.ts
@@ -5,10 +5,17 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 type ExecFileResult = { stdout?: string | Buffer };
+export const GIT_PROBE_TIMEOUT_MS = 2_000;
+
 export type ExecFileAsyncLike = (
   file: string,
   args: string[],
-  options: { cwd: string; encoding: "utf-8" },
+  options: {
+    cwd: string;
+    encoding: "utf-8";
+    timeout: number;
+    signal?: AbortSignal;
+  },
 ) => Promise<ExecFileResult>;
 
 export interface GitContext {
@@ -35,12 +42,20 @@ async function runGitCommand(
   args: string[],
   cwd: string,
   runner: ExecFileAsyncLike,
+  signal?: AbortSignal,
 ): Promise<{ stdout: string | undefined; ok: boolean }> {
+  signal?.throwIfAborted();
   try {
-    const result = await runner("git", args, { cwd, encoding: "utf-8" });
+    const result = await runner("git", args, {
+      cwd,
+      encoding: "utf-8",
+      timeout: GIT_PROBE_TIMEOUT_MS,
+      ...(signal ? { signal } : {}),
+    });
     const stdout = typeof result.stdout === "string" ? result.stdout : result.stdout?.toString();
     return { stdout, ok: true };
   } catch {
+    signal?.throwIfAborted();
     return { stdout: undefined, ok: false };
   }
 }
@@ -49,8 +64,9 @@ async function readGitTrimmed(
   args: string[],
   cwd: string,
   runner: ExecFileAsyncLike,
+  signal?: AbortSignal,
 ): Promise<{ value: string | undefined; ok: boolean }> {
-  const { stdout, ok } = await runGitCommand(args, cwd, runner);
+  const { stdout, ok } = await runGitCommand(args, cwd, runner, signal);
   const trimmed = stdout?.trim();
   return { value: trimmed ? trimmed : undefined, ok };
 }
@@ -58,18 +74,21 @@ async function readGitTrimmed(
 export async function probeGitBranch(
   cwd = process.cwd(),
   runner: ExecFileAsyncLike = execFileAsync as ExecFileAsyncLike,
+  signal?: AbortSignal,
 ): Promise<string | undefined> {
-  return (await readGitTrimmed(["branch", "--show-current"], cwd, runner)).value;
+  return (await readGitTrimmed(["branch", "--show-current"], cwd, runner, signal)).value;
 }
 
 async function probeGitDirty(
   cwd: string,
   runner: ExecFileAsyncLike,
+  signal?: AbortSignal,
 ): Promise<{ dirty?: boolean; dirtyFileCount?: number; ok: boolean }> {
   const { stdout, ok } = await runGitCommand(
     ["status", "--porcelain", "--untracked-files=normal"],
     cwd,
     runner,
+    signal,
   );
   if (!ok) {
     return { ok: false };
@@ -85,9 +104,10 @@ async function probeGitDirty(
 export async function probeGitDynamic(
   cwd = process.cwd(),
   runner: ExecFileAsyncLike = execFileAsync as ExecFileAsyncLike,
+  signal?: AbortSignal,
 ): Promise<GitDynamicState> {
-  const branchProbe = await readGitTrimmed(["branch", "--show-current"], cwd, runner);
-  const dirtyProbe = await probeGitDirty(cwd, runner);
+  const branchProbe = await readGitTrimmed(["branch", "--show-current"], cwd, runner, signal);
+  const dirtyProbe = await probeGitDirty(cwd, runner, signal);
 
   return {
     ...(branchProbe.value ? { branch: branchProbe.value } : {}),
@@ -102,9 +122,11 @@ export async function probeGitDynamic(
 export async function probeGitContext(
   cwd = process.cwd(),
   runner: ExecFileAsyncLike = execFileAsync as ExecFileAsyncLike,
+  signal?: AbortSignal,
 ): Promise<GitContext> {
-  const repoRoot = (await readGitTrimmed(["rev-parse", "--show-toplevel"], cwd, runner)).value;
-  const dynamic = await probeGitDynamic(cwd, runner);
+  const repoRoot = (await readGitTrimmed(["rev-parse", "--show-toplevel"], cwd, runner, signal))
+    .value;
+  const dynamic = await probeGitDynamic(cwd, runner, signal);
   const resolvedRepoRoot = repoRoot ?? cwd;
 
   return {
@@ -120,21 +142,49 @@ export async function probeGitContext(
 }
 
 export interface GitContextCache {
-  get(): Promise<GitContext>;
+  get(signal?: AbortSignal): Promise<GitContext>;
   peek(): GitContext | null;
   clear(): void;
 }
 
-export function createGitContextCache(loader: () => Promise<GitContext>): GitContextCache {
+function waitForGitContext(
+  promise: Promise<GitContext>,
+  signal?: AbortSignal,
+): Promise<GitContext> {
+  if (!signal) return promise;
+  signal.throwIfAborted();
+  return new Promise((resolve, reject) => {
+    const abort = () => {
+      signal.removeEventListener("abort", abort);
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", abort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", abort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", abort);
+        reject(error);
+      },
+    );
+  });
+}
+
+export function createGitContextCache(
+  loader: (signal?: AbortSignal) => Promise<GitContext>,
+): GitContextCache {
   let cached: GitContext | null = null;
   let inflight: Promise<GitContext> | null = null;
 
   return {
-    async get(): Promise<GitContext> {
+    async get(signal?: AbortSignal): Promise<GitContext> {
+      signal?.throwIfAborted();
       if (cached) return cached;
-      if (inflight) return inflight;
+      if (inflight) return waitForGitContext(inflight, signal);
 
-      inflight = loader()
+      inflight = loader(signal)
         .then((result) => {
           cached = result;
           return result;
@@ -143,7 +193,7 @@ export function createGitContextCache(loader: () => Promise<GitContext>): GitCon
           inflight = null;
         });
 
-      return inflight;
+      return waitForGitContext(inflight, signal);
     },
 
     peek(): GitContext | null {

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1427,11 +1427,13 @@ describe("slack-bridge top-level shutdown", () => {
     await sessionStart?.({}, ctx);
     await Promise.resolve();
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "https://slack.com/api/apps.connections.open",
-      expect.any(Object),
-    );
-    expect(FakeWebSocket.instances).toHaveLength(1);
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://slack.com/api/apps.connections.open",
+        expect.any(Object),
+      );
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
 
     await pinetStatus?.handler("status", ctx);
 
@@ -1517,11 +1519,13 @@ describe("slack-bridge top-level shutdown", () => {
     await sessionStart?.({}, ctx);
     await Promise.resolve();
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "https://slack.com/api/apps.connections.open",
-      expect.any(Object),
-    );
-    expect(FakeWebSocket.instances).toHaveLength(1);
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://slack.com/api/apps.connections.open",
+        expect.any(Object),
+      );
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
     expect(notify).toHaveBeenCalledWith(
       expect.stringContaining(
         "Slack access is default-deny because no allowedUsers are configured.",
@@ -1647,11 +1651,13 @@ describe("slack-bridge top-level shutdown", () => {
     await sessionStart?.({}, ctx);
     await Promise.resolve();
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "https://slack.com/api/apps.connections.open",
-      expect.any(Object),
-    );
-    expect(FakeWebSocket.instances).toHaveLength(1);
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://slack.com/api/apps.connections.open",
+        expect.any(Object),
+      );
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
     expect(notify).toHaveBeenCalledWith(
       expect.stringContaining("runtime guardrails are effectively empty"),
       "warning",
@@ -1927,8 +1933,9 @@ describe("slack-bridge top-level shutdown", () => {
     expect(pinetStart).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await Promise.resolve();
-    expect(FakeWebSocket.instances).toHaveLength(1);
+    await vi.waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
 
     await pinetStart?.handler("start", ctx);
 
@@ -2036,7 +2043,9 @@ describe("slack-bridge top-level shutdown", () => {
     expect(sessionShutdown).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await Promise.resolve();
+    await vi.waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
 
     const socket = FakeWebSocket.instances[0] as unknown as {
       emitEvent: (type: string, ...args: unknown[]) => void;
@@ -2179,7 +2188,9 @@ describe("slack-bridge top-level shutdown", () => {
     expect(slackSend).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await Promise.resolve();
+    await vi.waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
 
     const socket = FakeWebSocket.instances[0] as unknown as {
       emitEvent: (type: string, ...args: unknown[]) => void;
@@ -2377,12 +2388,13 @@ describe("slack-bridge top-level shutdown", () => {
 
     try {
       const startup = sessionStart?.({}, ctx);
-      await Promise.resolve();
-      expect(
-        fetchSpy.mock.calls.some(
-          (call) => String(call.at(0)) === "https://slack.com/api/apps.connections.open",
-        ),
-      ).toBe(true);
+      await vi.waitFor(() => {
+        expect(
+          fetchSpy.mock.calls.some(
+            (call) => String(call.at(0)) === "https://slack.com/api/apps.connections.open",
+          ),
+        ).toBe(true);
+      });
 
       await pinetStart?.handler("start", ctx);
       await startup;

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1362,6 +1362,137 @@ describe("slack-bridge top-level shutdown", () => {
     expect(setStatus).toHaveBeenCalled();
   });
 
+  it("returns from session start before Slack connects and keeps managed tools inactive", async () => {
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        "slack-bridge": { runtimeMode: "single", allowAllWorkspaceUsers: true },
+      }),
+    );
+
+    const events = new Map<string, EventHandler>();
+    const FakeWebSocket = createFakeWebSocketClass();
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as never as ExtensionAPI;
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: { fg: (_color: string, text: string) => text },
+        notify: vi.fn(),
+        setStatus: vi.fn(),
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "background-start-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-background-start.json",
+      },
+    } as never as ExtensionContext;
+    let resolveSocket!: (response: Response) => void;
+    const socketResponse = new Promise<Response>((resolve) => {
+      resolveSocket = resolve;
+    });
+    const fetchSpy = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/apps.connections.open")) return socketResponse;
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchSpy as never as typeof fetch);
+    vi.stubGlobal("WebSocket", FakeWebSocket as never as typeof WebSocket);
+
+    slackBridge(pi);
+
+    await expect(events.get("session_start")?.({}, ctx)).resolves.toBeUndefined();
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://slack.com/api/apps.connections.open",
+        expect.any(Object),
+      );
+    });
+    expect(pi.getActiveTools()).toEqual(["read"]);
+
+    resolveSocket(
+      new Response(JSON.stringify({ ok: true, url: "wss://slack.example/socket" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    await vi.waitFor(() => {
+      expect(pi.getActiveTools()).toContain("slack");
+    });
+
+    await events.get("session_shutdown")?.({}, ctx);
+  });
+
+  it("cancels a pending follower connection before session shutdown", async () => {
+    const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        "slack-bridge": { runtimeMode: "follower", allowAllWorkspaceUsers: true },
+      }),
+    );
+
+    const events = new Map<string, EventHandler>();
+    const pi = {
+      appendEntry: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+      on: vi.fn((eventName: string, handler: EventHandler) => {
+        events.set(eventName, handler);
+      }),
+      sendUserMessage: vi.fn(),
+    } as never as ExtensionAPI;
+    const ctx = {
+      cwd: process.cwd(),
+      hasUI: true,
+      isIdle: () => true,
+      ui: {
+        theme: { fg: (_color: string, text: string) => text },
+        notify: vi.fn(),
+        setStatus: vi.fn(),
+      },
+      sessionManager: {
+        getEntries: () => [],
+        getHeader: () => null,
+        getLeafId: () => "pending-follower-leaf",
+        getSessionFile: () => "/tmp/slack-bridge-pending-follower.json",
+      },
+    } as never as ExtensionContext;
+    let rejectConnect!: (error: Error) => void;
+    const connectSpy = vi.spyOn(BrokerClient.prototype, "connect").mockImplementation(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectConnect = reject;
+        }),
+    );
+    const disconnectSpy = vi.spyOn(BrokerClient.prototype, "disconnect").mockImplementation(() => {
+      rejectConnect(new Error("follower startup cancelled"));
+    });
+
+    slackBridge(pi);
+
+    await expect(events.get("session_start")?.({}, ctx)).resolves.toBeUndefined();
+    await vi.waitFor(() => {
+      expect(connectSpy).toHaveBeenCalledOnce();
+    });
+    await expect(events.get("session_shutdown")?.({}, ctx)).resolves.toBeUndefined();
+
+    expect(disconnectSpy).toHaveBeenCalled();
+    expect(pi.getActiveTools()).toEqual(["read"]);
+  });
+
   it("starts explicit single runtime mode on session start and reports it in /pinet status", async () => {
     const settingsPath = `${process.env.HOME}/.pi/agent/settings.json`;
     fs.mkdirSync(`${process.env.HOME}/.pi/agent`, { recursive: true });

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -47,6 +47,7 @@ const BROKER_MANAGED_PINET_ENV_KEYS = [
   "PINET_LAUNCH_SOURCE",
   "PINET_BROKER_AGENT_ID",
   "PINET_TMUX_SESSION",
+  "PINET_SOCKET_PATH",
 ] as const;
 
 const originalBrokerManagedPinetEnv = Object.fromEntries(
@@ -1443,6 +1444,9 @@ describe("slack-bridge top-level shutdown", () => {
         "slack-bridge": { runtimeMode: "follower", allowAllWorkspaceUsers: true },
       }),
     );
+    const socketPath = path.join(testHome, "pinet.sock");
+    fs.writeFileSync(socketPath, "");
+    process.env.PINET_SOCKET_PATH = socketPath;
 
     const events = new Map<string, EventHandler>();
     const pi = {

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1420,7 +1420,7 @@ describe("slack-bridge top-level shutdown", () => {
         expect.any(Object),
       );
     });
-    expect(pi.getActiveTools()).toEqual(["read"]);
+    expect(pi.getActiveTools()).not.toContain("slack");
 
     resolveSocket(
       new Response(JSON.stringify({ ok: true, url: "wss://slack.example/socket" }), {
@@ -1490,7 +1490,7 @@ describe("slack-bridge top-level shutdown", () => {
     await expect(events.get("session_shutdown")?.({}, ctx)).resolves.toBeUndefined();
 
     expect(disconnectSpy).toHaveBeenCalled();
-    expect(pi.getActiveTools()).toEqual(["read"]);
+    expect(pi.getActiveTools()).not.toContain("pinet");
   });
 
   it("starts explicit single runtime mode on session start and reports it in /pinet status", async () => {
@@ -1556,7 +1556,6 @@ describe("slack-bridge top-level shutdown", () => {
     expect(pinetStatus).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await Promise.resolve();
 
     await vi.waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
@@ -1648,7 +1647,6 @@ describe("slack-bridge top-level shutdown", () => {
     expect(pinetStatus).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await Promise.resolve();
 
     await vi.waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
@@ -1780,7 +1778,6 @@ describe("slack-bridge top-level shutdown", () => {
     expect(pinetStatus).toBeDefined();
 
     await sessionStart?.({}, ctx);
-    await Promise.resolve();
 
     await vi.waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(

--- a/slack-bridge/index.test.ts
+++ b/slack-bridge/index.test.ts
@@ -1471,12 +1471,17 @@ describe("slack-bridge top-level shutdown", () => {
       },
     } as never as ExtensionContext;
     let rejectConnect!: (error: Error) => void;
-    const connectSpy = vi.spyOn(BrokerClient.prototype, "connect").mockImplementation(
-      () =>
-        new Promise<void>((_resolve, reject) => {
-          rejectConnect = reject;
-        }),
-    );
+    const pendingConnect = new Promise<void>((_resolve, reject) => {
+      rejectConnect = reject;
+    });
+    let notifyConnectStarted!: () => void;
+    const connectStarted = new Promise<void>((resolve) => {
+      notifyConnectStarted = resolve;
+    });
+    const connectSpy = vi.spyOn(BrokerClient.prototype, "connect").mockImplementation(() => {
+      notifyConnectStarted();
+      return pendingConnect;
+    });
     const disconnectSpy = vi.spyOn(BrokerClient.prototype, "disconnect").mockImplementation(() => {
       rejectConnect(new Error("follower startup cancelled"));
     });
@@ -1484,9 +1489,8 @@ describe("slack-bridge top-level shutdown", () => {
     slackBridge(pi);
 
     await expect(events.get("session_start")?.({}, ctx)).resolves.toBeUndefined();
-    await vi.waitFor(() => {
-      expect(connectSpy).toHaveBeenCalledOnce();
-    });
+    await connectStarted;
+    expect(connectSpy).toHaveBeenCalledOnce();
     await expect(events.get("session_shutdown")?.({}, ctx)).resolves.toBeUndefined();
 
     expect(disconnectSpy).toHaveBeenCalled();

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -16,6 +16,7 @@ import {
   resolveAgentStableId,
   resolveAllowAllWorkspaceUsers,
   trackBrokerInboundThread,
+  isAbortError,
 } from "./helpers.js";
 import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
@@ -298,7 +299,9 @@ export default function (pi: ExtensionAPI) {
 
   // ─── Helpers ─────────────────────────────────────────
 
-  const gitContextCache = createGitContextCache(() => probeGitContext(process.cwd()));
+  const gitContextCache = createGitContextCache((signal) =>
+    probeGitContext(process.cwd(), undefined, signal),
+  );
   const runtimeAgentContext = createRuntimeAgentContext({
     cwd: process.cwd(),
     getSettings: () => settings,
@@ -689,6 +692,7 @@ export default function (pi: ExtensionAPI) {
   let brokerClient: BrokerClientRef | null = null;
   let pinetLifecycleTail: Promise<void> = Promise.resolve();
   let pinetReloadPromise: Promise<void> | null = null;
+  let pendingStartup: { controller: AbortController; promise: Promise<void> } | null = null;
   let followerRuntimeDiagnostic: FollowerRuntimeDiagnostic | null = null;
   const followerDeliveryState = createFollowerDeliveryState();
   let desiredAgentStatus: "working" | "idle" = "idle";
@@ -1173,60 +1177,87 @@ export default function (pi: ExtensionAPI) {
     return run;
   }
 
+  async function cancelPendingStartup(): Promise<void> {
+    const startup = pendingStartup;
+    if (!startup) return;
+    startup.controller.abort();
+    await startup.promise.catch(() => {
+      /* startup reports and contains its own cleanup failures */
+    });
+  }
+
+  function runRuntimeModeTransition(
+    ctx: ExtensionContext,
+    mode: SlackBridgeRuntimeMode,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    return runPinetLifecycle(async () => {
+      signal?.throwIfAborted();
+      if (currentRuntimeMode === mode) {
+        if (mode === "off") {
+          setExtStatus(ctx, "off");
+        }
+        await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
+        signal?.throwIfAborted();
+        return;
+      }
+
+      if (currentRuntimeMode !== "off") {
+        if (pinetReloadPromise) {
+          await pinetReloadPromise.catch(() => {
+            /* transition from the restored runtime */
+          });
+        }
+        await stopPinetRuntime(ctx, { releaseIdentity: true });
+        signal?.throwIfAborted();
+        // Runtime transitions keep the extension alive in-process, so restore a
+        // fresh top-level Slack request tracker after tearing the prior runtime down.
+        slackRequestRuntime.reset();
+        singlePlayerRuntime.resetShutdownState();
+      }
+
+      if (mode === "off") {
+        currentRuntimeMode = "off";
+        setExtStatus(ctx, "off");
+        return;
+      }
+
+      // A prior transition may have aborted the shared Slack request generation.
+      // Every fresh runtime starts with an independent, usable tracker.
+      slackRequestRuntime.reset();
+      singlePlayerRuntime.resetShutdownState();
+
+      if (mode === "single") {
+        currentRuntimeMode = "single";
+        setExtStatus(ctx, "reconnecting");
+        await singlePlayerRuntime.connect(ctx, signal);
+        signal?.throwIfAborted();
+        botUserId = singlePlayerRuntime.getBotUserId() ?? botUserId;
+        await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
+        signal?.throwIfAborted();
+        void ensureSlackScopeDiagnostics(ctx);
+        return;
+      }
+
+      if (mode === "broker") {
+        await connectAsBroker(ctx, {}, signal);
+        signal?.throwIfAborted();
+        void ensureSlackScopeDiagnostics(ctx);
+        return;
+      }
+
+      await connectAsFollower(ctx, signal);
+      signal?.throwIfAborted();
+      void ensureSlackScopeDiagnostics(ctx);
+    });
+  }
+
   async function transitionToRuntimeMode(
     ctx: ExtensionContext,
     mode: SlackBridgeRuntimeMode,
   ): Promise<void> {
-    if (currentRuntimeMode === mode) {
-      if (mode === "off") {
-        setExtStatus(ctx, "off");
-      }
-      await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
-      return;
-    }
-
-    if (currentRuntimeMode !== "off") {
-      if (pinetReloadPromise) {
-        await pinetReloadPromise.catch(() => {
-          /* transition from the restored runtime */
-        });
-      }
-      await runPinetLifecycle(() => stopPinetRuntime(ctx, { releaseIdentity: true }));
-      // Runtime transitions keep the extension alive in-process, so restore a
-      // fresh top-level Slack request tracker after tearing the prior runtime down.
-      slackRequestRuntime.reset();
-      singlePlayerRuntime.resetShutdownState();
-    }
-
-    if (mode === "off") {
-      currentRuntimeMode = "off";
-      setExtStatus(ctx, "off");
-      return;
-    }
-
-    // A prior transition may have aborted the shared Slack request generation.
-    // Every fresh runtime starts with an independent, usable tracker.
-    slackRequestRuntime.reset();
-    singlePlayerRuntime.resetShutdownState();
-
-    if (mode === "single") {
-      currentRuntimeMode = "single";
-      setExtStatus(ctx, "reconnecting");
-      await singlePlayerRuntime.connect(ctx);
-      botUserId = singlePlayerRuntime.getBotUserId() ?? botUserId;
-      await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
-      void ensureSlackScopeDiagnostics(ctx);
-      return;
-    }
-
-    if (mode === "broker") {
-      await connectAsBroker(ctx);
-      void ensureSlackScopeDiagnostics(ctx);
-      return;
-    }
-
-    await connectAsFollower(ctx);
-    void ensureSlackScopeDiagnostics(ctx);
+    await cancelPendingStartup();
+    await runRuntimeModeTransition(ctx, mode);
   }
 
   /**
@@ -1254,15 +1285,13 @@ export default function (pi: ExtensionAPI) {
     await subtreeBrokerRuntime.stop({ releaseIdentity: options.releaseIdentity });
     await brokerRuntime.disconnect({ releaseIdentity: options.releaseIdentity });
 
-    if (brokerClient) {
-      await followerRuntime
-        .disconnect(ctx, { releaseIdentity: options.releaseIdentity })
-        .catch(() => {
-          /* best effort */
-        });
-      brokerClient = null;
-      followerRuntimeDiagnostic = null;
-    }
+    await followerRuntime
+      .disconnect(ctx, { releaseIdentity: options.releaseIdentity })
+      .catch(() => {
+        /* best effort */
+      });
+    brokerClient = null;
+    followerRuntimeDiagnostic = null;
 
     await singlePlayerRuntime.disconnect();
     brokerRole = null;
@@ -1274,6 +1303,7 @@ export default function (pi: ExtensionAPI) {
   }
 
   async function reloadPinetRuntime(ctx: ExtensionContext): Promise<void> {
+    await cancelPendingStartup();
     if (pinetReloadPromise) {
       await pinetReloadPromise;
       return;
@@ -1531,7 +1561,9 @@ export default function (pi: ExtensionAPI) {
   async function connectAsBroker(
     ctx: ExtensionContext,
     options: { refreshSettings?: boolean } = {},
+    signal?: AbortSignal,
   ): Promise<void> {
+    signal?.throwIfAborted();
     setExtStatus(ctx, "reconnecting");
     if (options.refreshSettings !== false) {
       refreshSettings();
@@ -1544,7 +1576,8 @@ export default function (pi: ExtensionAPI) {
       recoveredBrokerMessages,
       recoveredTargetedBacklogCount,
       releasedBrokerClaims,
-    } = await brokerRuntime.connect(ctx);
+    } = await brokerRuntime.connect(ctx, signal);
+    signal?.throwIfAborted();
     const broker = brokerRuntime.getBroker();
     if (!broker) {
       throw new Error("Broker runtime failed to initialize.");
@@ -1567,8 +1600,19 @@ export default function (pi: ExtensionAPI) {
       } else {
         try {
           const imessageAdapter = createIMessageAdapter();
-          await imessageAdapter.connect();
-          broker.addAdapter(imessageAdapter);
+          const abortConnect = () => {
+            void imessageAdapter.disconnect().catch(() => {
+              /* the broker startup path owns connection failures */
+            });
+          };
+          signal?.addEventListener("abort", abortConnect, { once: true });
+          try {
+            await imessageAdapter.connect();
+            signal?.throwIfAborted();
+            broker.addAdapter(imessageAdapter);
+          } finally {
+            signal?.removeEventListener("abort", abortConnect);
+          }
 
           if (environment.blockers.length > 0) {
             ctx.ui.notify(`iMessage send-first mode enabled — ${readinessSummary}`, "warning");
@@ -1593,6 +1637,7 @@ export default function (pi: ExtensionAPI) {
       }
     }
 
+    signal?.throwIfAborted();
     broker.server.setOutboundMessageAdapters?.(broker.adapters);
 
     brokerRole = "broker";
@@ -1763,10 +1808,12 @@ export default function (pi: ExtensionAPI) {
 
   commandRegistrationRuntime.register(pi);
 
-  async function connectAsFollower(ctx: ExtensionContext): Promise<void> {
+  async function connectAsFollower(ctx: ExtensionContext, signal?: AbortSignal): Promise<void> {
+    signal?.throwIfAborted();
     pinetRegistrationGate.assertCanRegister();
 
-    const clientRef = await followerRuntime.connect(ctx);
+    const clientRef = await followerRuntime.connect(ctx, signal);
+    signal?.throwIfAborted();
     brokerClient = clientRef;
     followerRuntimeDiagnostic = null;
     brokerRole = "follower";
@@ -1799,6 +1846,7 @@ export default function (pi: ExtensionAPI) {
   // ─── Lifecycle ──────────────────────────────────────
 
   pi.on("session_start", async (_event, ctx) => {
+    await cancelPendingStartup();
     compactionGate.reset();
     singlePlayerRuntime.resetShutdownState();
     slackRequestRuntime.reset();
@@ -1824,26 +1872,59 @@ export default function (pi: ExtensionAPI) {
       brokerManagedFollowerLaunch: isBrokerManagedFollowerLaunch(),
     });
 
-    try {
+    if (startupMode === "off") {
       await transitionToRuntimeMode(ctx, startupMode);
-      if (startupMode === "single") {
-        maybeWarnSlackGuardrailPosture(ctx);
-        console.log("[slack-bridge] runtime mode: single");
-      } else if (startupMode === "follower") {
-        console.log("[slack-bridge] runtime mode: follower");
-      } else if (startupMode === "broker") {
-        console.log("[slack-bridge] runtime mode: broker");
-      }
-    } catch (err) {
-      console.error(`[slack-bridge] runtime start (${startupMode}) failed: ${msg(err)}`);
-      currentRuntimeMode = "off";
-      brokerRole = null;
-      pinetEnabled = false;
-      slackRequestRuntime.reset();
-      singlePlayerRuntime.resetShutdownState();
-      setExtStatus(ctx, "off");
-      await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
+      return;
     }
+
+    // Runtime connection can involve Git probes, SQLite, Slack HTTP, and a
+    // Socket Mode handshake. Keep managed tools unavailable until it finishes,
+    // but let Pi render its UI while the queued startup runs in the background.
+    await toolRegistrationRuntime.sync(pi, "off");
+    setExtStatus(ctx, "reconnecting");
+    const controller = new AbortController();
+    const startupRecord = {
+      controller,
+      promise: Promise.resolve(),
+    };
+    startupRecord.promise = runRuntimeModeTransition(ctx, startupMode, controller.signal)
+      .then(() => {
+        if (startupMode === "single") {
+          maybeWarnSlackGuardrailPosture(ctx);
+          console.log("[slack-bridge] runtime mode: single");
+        } else if (startupMode === "follower") {
+          console.log("[slack-bridge] runtime mode: follower");
+        } else {
+          console.log("[slack-bridge] runtime mode: broker");
+        }
+      })
+      .catch(async (err) => {
+        const cancelled = controller.signal.aborted || isAbortError(err);
+        if (!cancelled) {
+          console.error(`[slack-bridge] runtime start (${startupMode}) failed: ${msg(err)}`);
+        }
+        await runPinetLifecycle(() => stopPinetRuntime(ctx, { releaseIdentity: !cancelled })).catch(
+          (cleanupError) => {
+            console.error(`[slack-bridge] runtime cleanup failed: ${msg(cleanupError)}`);
+          },
+        );
+        currentRuntimeMode = "off";
+        brokerRole = null;
+        pinetEnabled = false;
+        slackRequestRuntime.reset();
+        singlePlayerRuntime.resetShutdownState();
+        setExtStatus(ctx, "off");
+        await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
+      })
+      .finally(() => {
+        if (pendingStartup === startupRecord) {
+          pendingStartup = null;
+        }
+      })
+      .catch((err) => {
+        console.error(`[slack-bridge] background runtime start failed: ${msg(err)}`);
+      });
+    pendingStartup = startupRecord;
   });
 
   // ─── Agent event wiring ──────────────────────────────
@@ -1863,6 +1944,7 @@ export default function (pi: ExtensionAPI) {
     resetRemoteControlState();
     resetPendingRemoteControlAcks();
     sessionUiRuntime.cleanupForSessionShutdown();
+    await cancelPendingStartup();
     await runPinetLifecycle(() => stopPinetRuntime(ctx, { releaseIdentity: true }));
     pinetRegistrationGate.reset();
   });

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -360,7 +360,7 @@ export default function (pi: ExtensionAPI) {
     getExtensionContext: sessionUiRuntime.getExtensionContext,
     persistState,
     updateBadge,
-    getGitContext: () => gitContextCache.get(),
+    getGitContext: (signal) => gitContextCache.get(signal),
   });
   const {
     isUserAllowed,
@@ -1181,9 +1181,7 @@ export default function (pi: ExtensionAPI) {
     const startup = pendingStartup;
     if (!startup) return;
     startup.controller.abort();
-    await startup.promise.catch(() => {
-      /* startup reports and contains its own cleanup failures */
-    });
+    await startup.promise;
   }
 
   function runRuntimeModeTransition(
@@ -1198,7 +1196,6 @@ export default function (pi: ExtensionAPI) {
           setExtStatus(ctx, "off");
         }
         await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
-        signal?.throwIfAborted();
         return;
       }
 
@@ -1210,22 +1207,16 @@ export default function (pi: ExtensionAPI) {
         }
         await stopPinetRuntime(ctx, { releaseIdentity: true });
         signal?.throwIfAborted();
-        // Runtime transitions keep the extension alive in-process, so restore a
-        // fresh top-level Slack request tracker after tearing the prior runtime down.
-        slackRequestRuntime.reset();
-        singlePlayerRuntime.resetShutdownState();
       }
+
+      slackRequestRuntime.reset();
+      singlePlayerRuntime.resetShutdownState();
 
       if (mode === "off") {
         currentRuntimeMode = "off";
         setExtStatus(ctx, "off");
         return;
       }
-
-      // A prior transition may have aborted the shared Slack request generation.
-      // Every fresh runtime starts with an independent, usable tracker.
-      slackRequestRuntime.reset();
-      singlePlayerRuntime.resetShutdownState();
 
       if (mode === "single") {
         currentRuntimeMode = "single";
@@ -1883,11 +1874,7 @@ export default function (pi: ExtensionAPI) {
     await toolRegistrationRuntime.sync(pi, "off");
     setExtStatus(ctx, "reconnecting");
     const controller = new AbortController();
-    const startupRecord = {
-      controller,
-      promise: Promise.resolve(),
-    };
-    startupRecord.promise = runRuntimeModeTransition(ctx, startupMode, controller.signal)
+    const startupPromise = runRuntimeModeTransition(ctx, startupMode, controller.signal)
       .then(() => {
         if (startupMode === "single") {
           maybeWarnSlackGuardrailPosture(ctx);
@@ -1908,23 +1895,16 @@ export default function (pi: ExtensionAPI) {
             console.error(`[slack-bridge] runtime cleanup failed: ${msg(cleanupError)}`);
           },
         );
-        currentRuntimeMode = "off";
-        brokerRole = null;
-        pinetEnabled = false;
         slackRequestRuntime.reset();
         singlePlayerRuntime.resetShutdownState();
-        setExtStatus(ctx, "off");
-        await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
       })
       .finally(() => {
-        if (pendingStartup === startupRecord) {
-          pendingStartup = null;
-        }
+        if (pendingStartup?.controller === controller) pendingStartup = null;
       })
       .catch((err) => {
         console.error(`[slack-bridge] background runtime start failed: ${msg(err)}`);
       });
-    pendingStartup = startupRecord;
+    pendingStartup = { controller, promise: startupPromise };
   });
 
   // ─── Agent event wiring ──────────────────────────────

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -1204,6 +1204,11 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
+    // A prior transition may have aborted the shared Slack request generation.
+    // Every fresh runtime starts with an independent, usable tracker.
+    slackRequestRuntime.reset();
+    singlePlayerRuntime.resetShutdownState();
+
     if (mode === "single") {
       currentRuntimeMode = "single";
       setExtStatus(ctx, "reconnecting");
@@ -1832,6 +1837,10 @@ export default function (pi: ExtensionAPI) {
     } catch (err) {
       console.error(`[slack-bridge] runtime start (${startupMode}) failed: ${msg(err)}`);
       currentRuntimeMode = "off";
+      brokerRole = null;
+      pinetEnabled = false;
+      slackRequestRuntime.reset();
+      singlePlayerRuntime.resetShutdownState();
       setExtStatus(ctx, "off");
       await toolRegistrationRuntime.sync(pi, currentRuntimeMode);
     }

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -21,7 +21,6 @@ import {
 import { buildSecurityPrompt, type SecurityGuardrails } from "./guardrails.js";
 import { TtlCache, TtlSet } from "./ttl-cache.js";
 import { resolveReactionCommands } from "./reaction-triggers.js";
-import { DEFAULT_SOCKET_PATH } from "./broker/client.js";
 import {
   inspectBrokerLock,
   probeBrokerSocket,
@@ -64,7 +63,11 @@ import {
   markFollowerInboxIdsDelivered,
   queueFollowerInboxIds,
 } from "./follower-delivery.js";
-import { createFollowerRuntime, type BrokerClientRef } from "./follower-runtime.js";
+import {
+  createFollowerRuntime,
+  resolveBrokerSocketPath,
+  type BrokerClientRef,
+} from "./follower-runtime.js";
 import {
   createSinglePlayerRuntime,
   type SinglePlayerPendingAttentionEntry,
@@ -1859,7 +1862,7 @@ export default function (pi: ExtensionAPI) {
     refreshSettings();
     maybeWarnSlackUserAccess(ctx);
     const startupMode = resolveSlackBridgeStartupRuntimeMode(settings, {
-      brokerSocketExists: fs.existsSync(DEFAULT_SOCKET_PATH),
+      brokerSocketExists: fs.existsSync(resolveBrokerSocketPath()),
       brokerManagedFollowerLaunch: isBrokerManagedFollowerLaunch(),
     });
 

--- a/slack-bridge/pinet-runtime-composition.test.ts
+++ b/slack-bridge/pinet-runtime-composition.test.ts
@@ -67,10 +67,7 @@ describe("Pinet runtime composition", () => {
           rejectConnect = reject;
         }),
     );
-    vi.spyOn(adapter, "disconnect").mockImplementation(async () => {
-      adapter.connected = false;
-      rejectConnect(new Error("adapter startup aborted"));
-    });
+    vi.spyOn(adapter, "disconnect");
     const controller = new AbortController();
 
     const connecting = connectPinetRuntimeAdapters({
@@ -83,9 +80,12 @@ describe("Pinet runtime composition", () => {
       expect(adapter.connect).toHaveBeenCalled();
     });
     controller.abort();
+    await vi.waitFor(() => {
+      expect(adapter.disconnect).toHaveBeenCalledOnce();
+    });
+    rejectConnect(new Error("adapter startup failed"));
 
-    await expect(connecting).rejects.toThrow("adapter startup aborted");
-    expect(adapter.disconnect).toHaveBeenCalledOnce();
+    await expect(connecting).rejects.toThrow("adapter startup failed");
   });
 
   it("connects a non-Slack adapter at the Pinet core composition boundary", async () => {

--- a/slack-bridge/pinet-runtime-composition.test.ts
+++ b/slack-bridge/pinet-runtime-composition.test.ts
@@ -58,6 +58,36 @@ describe("Pinet runtime composition", () => {
     expect(bindings).toEqual([{ adapter: matrixAdapter }]);
   });
 
+  it("disconnects an adapter when startup is aborted", async () => {
+    let rejectConnect!: (error: Error) => void;
+    const adapter = new MemoryAdapter("matrix");
+    vi.spyOn(adapter, "connect").mockImplementation(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectConnect = reject;
+        }),
+    );
+    vi.spyOn(adapter, "disconnect").mockImplementation(async () => {
+      adapter.connected = false;
+      rejectConnect(new Error("adapter startup aborted"));
+    });
+    const controller = new AbortController();
+
+    const connecting = connectPinetRuntimeAdapters({
+      broker: { addAdapter: vi.fn() },
+      bindings: [{ adapter }],
+      onInbound: vi.fn(),
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => {
+      expect(adapter.connect).toHaveBeenCalled();
+    });
+    controller.abort();
+
+    await expect(connecting).rejects.toThrow("adapter startup aborted");
+    expect(adapter.disconnect).toHaveBeenCalledOnce();
+  });
+
   it("connects a non-Slack adapter at the Pinet core composition boundary", async () => {
     const matrixAdapter = new MemoryAdapter("matrix");
     const addAdapter = vi.fn();

--- a/slack-bridge/pinet-runtime-composition.ts
+++ b/slack-bridge/pinet-runtime-composition.ts
@@ -28,6 +28,7 @@ export interface ConnectPinetRuntimeAdaptersOptions {
   broker: Pick<Broker, "addAdapter">;
   bindings: PinetRuntimeAdapterBinding[];
   onInbound: (message: InboundMessage) => void;
+  signal?: AbortSignal;
 }
 
 export interface ConnectPinetRuntimeAdaptersResult {
@@ -57,14 +58,27 @@ export async function connectPinetRuntimeAdapters({
   broker,
   bindings,
   onInbound,
+  signal,
 }: ConnectPinetRuntimeAdaptersOptions): Promise<ConnectPinetRuntimeAdaptersResult> {
   let botUserId: string | null = null;
 
   for (const binding of bindings) {
+    signal?.throwIfAborted();
     binding.adapter.onInbound(onInbound);
     broker.addAdapter(binding.adapter);
-    await binding.adapter.connect();
-    botUserId ??= binding.getBotUserId?.() ?? null;
+    const abortConnect = () => {
+      void binding.adapter.disconnect().catch(() => {
+        /* the connect path owns startup failures */
+      });
+    };
+    signal?.addEventListener("abort", abortConnect, { once: true });
+    try {
+      await binding.adapter.connect();
+      signal?.throwIfAborted();
+      botUserId ??= binding.getBotUserId?.() ?? null;
+    } finally {
+      signal?.removeEventListener("abort", abortConnect);
+    }
   }
 
   return { botUserId };

--- a/slack-bridge/pinet-tools.ts
+++ b/slack-bridge/pinet-tools.ts
@@ -16,14 +16,7 @@ import {
   parseScheduledWakeupDelay,
   resolveScheduledWakeupFireAt,
 } from "@pinet/pinet-core/scheduled-wakeups";
-import {
-  DEFAULT_MAX_BYTES,
-  DEFAULT_MAX_LINES,
-  formatSize,
-  truncateHead,
-  type ExtensionAPI,
-  type ExtensionContext,
-} from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import {
@@ -51,6 +44,12 @@ import {
   SubtreeSpawnRegistrationTimeoutError,
   type SubtreeSpawnLaunchHandle,
 } from "./subtree-broker-runtime.js";
+import {
+  DEFAULT_MAX_OUTPUT_BYTES,
+  DEFAULT_MAX_OUTPUT_LINES,
+  formatOutputSize,
+  measureHeadTruncation,
+} from "./tool-output-limits.js";
 import type {
   AgentSessionSearchInfo,
   AgentSessionSearchOptions,
@@ -613,10 +612,7 @@ function wrapDispatcherEnvelope(
     output.format === "json"
       ? renderedText
       : `${renderedText}\n\n--- Pinet dispatcher envelope (JSON) ---\n${JSON.stringify(envelope, null, 2)}`;
-  const truncation = truncateHead(fullOutputText, {
-    maxLines: DEFAULT_MAX_LINES,
-    maxBytes: DEFAULT_MAX_BYTES,
-  });
+  const truncation = measureHeadTruncation(fullOutputText);
 
   let returnedEnvelope = envelope;
   let returnedText = renderedText;
@@ -696,8 +692,8 @@ function wrapDispatcherEnvelope(
       summary = `${subject} output exceeded the inline limit.`;
     }
 
-    const spillNotice = `[Output truncated: original was ${truncation.totalLines} line${truncation.totalLines === 1 ? "" : "s"} (${formatSize(truncation.totalBytes)}), exceeding the inline limit of ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)}. Full output saved to: ${fullOutputPath}]`;
-    const warning = `Pinet output exceeded ${formatSize(DEFAULT_MAX_BYTES)} / ${DEFAULT_MAX_LINES} lines; full output saved to ${fullOutputPath}.`;
+    const spillNotice = `[Output truncated: original was ${truncation.totalLines} line${truncation.totalLines === 1 ? "" : "s"} (${formatOutputSize(truncation.totalBytes)}), exceeding the inline limit of ${DEFAULT_MAX_OUTPUT_LINES} lines or ${formatOutputSize(DEFAULT_MAX_OUTPUT_BYTES)}. Full output saved to: ${fullOutputPath}]`;
+    const warning = `Pinet output exceeded ${formatOutputSize(DEFAULT_MAX_OUTPUT_BYTES)} / ${DEFAULT_MAX_OUTPUT_LINES} lines; full output saved to ${fullOutputPath}.`;
     returnedEnvelope = buildPinetDispatcherEnvelope(
       envelope.status,
       {
@@ -712,8 +708,8 @@ function wrapDispatcherEnvelope(
             totalBytes: truncation.totalBytes,
             outputLines: truncation.outputLines,
             outputBytes: truncation.outputBytes,
-            maxLines: DEFAULT_MAX_LINES,
-            maxBytes: DEFAULT_MAX_BYTES,
+            maxLines: DEFAULT_MAX_OUTPUT_LINES,
+            maxBytes: DEFAULT_MAX_OUTPUT_BYTES,
           },
           outputFormat: output.format,
         },

--- a/slack-bridge/runtime-agent-context.ts
+++ b/slack-bridge/runtime-agent-context.ts
@@ -79,9 +79,9 @@ export interface RuntimeAgentContextDeps {
   getExtensionContext: () => ExtensionContext | null;
   persistState: () => void;
   updateBadge: () => void;
-  getGitContext: () => Promise<GitContext>;
+  getGitContext: (signal?: AbortSignal) => Promise<GitContext>;
   /** Optional test hook for live branch/dirty probing. */
-  getDynamicGitState?: (cwd: string) => Promise<GitDynamicState>;
+  getDynamicGitState?: (cwd: string, signal?: AbortSignal) => Promise<GitDynamicState>;
 }
 
 export interface RuntimeAgentContext {
@@ -110,7 +110,10 @@ export interface RuntimeAgentContext {
   snapshotReloadableRuntime: () => ReloadableRuntimeSnapshot;
   restoreReloadableRuntime: (snapshot: ReloadableRuntimeSnapshot) => void;
   detectProjectTools: (repoRoot: string, cwd: string) => string[];
-  getAgentMetadata: (role?: RuntimeAgentRole) => Promise<Record<string, unknown>>;
+  getAgentMetadata: (
+    role?: RuntimeAgentRole,
+    signal?: AbortSignal,
+  ) => Promise<Record<string, unknown>>;
   asStringValue: (value: unknown) => string | undefined;
   getMeshRoleFromMetadata: (
     metadata: Record<string, unknown> | undefined,
@@ -371,20 +374,24 @@ export function createRuntimeAgentContext(deps: RuntimeAgentContextDeps): Runtim
     return [...tools].sort();
   }
 
-  const dynamicGitProbe = deps.getDynamicGitState ?? ((cwd: string) => probeGitDynamic(cwd));
+  const dynamicGitProbe =
+    deps.getDynamicGitState ??
+    ((cwd: string, signal?: AbortSignal) => probeGitDynamic(cwd, undefined, signal));
 
   async function getAgentMetadata(
     role: RuntimeAgentRole = "worker",
+    signal?: AbortSignal,
   ): Promise<Record<string, unknown>> {
-    const gitContext = await deps.getGitContext();
+    const gitContext = await deps.getGitContext(signal);
     const { cwd, repo, repoRoot } = gitContext;
     const resolvedRepoRoot = repoRoot ?? cwd;
     const tools = detectProjectTools(resolvedRepoRoot, cwd);
     const scope = buildSlackCompatibilityScope();
     let dynamic: GitDynamicState;
     try {
-      dynamic = await dynamicGitProbe(cwd);
+      dynamic = await dynamicGitProbe(cwd, signal);
     } catch {
+      signal?.throwIfAborted();
       dynamic = { probeFailed: true };
     }
     const branch = dynamic.branch;

--- a/slack-bridge/single-player-runtime.ts
+++ b/slack-bridge/single-player-runtime.ts
@@ -96,7 +96,7 @@ function interruptSinglePlayerTurn(ctx: ExtensionContext): void {
 }
 
 export interface SinglePlayerRuntime {
-  connect: (ctx: ExtensionContext) => Promise<void>;
+  connect: (ctx: ExtensionContext, signal?: AbortSignal) => Promise<void>;
   disconnect: () => Promise<void>;
   getBotUserId: () => string | null;
   isConnected: () => boolean;
@@ -518,7 +518,8 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
   };
 
   return {
-    async connect(ctx: ExtensionContext): Promise<void> {
+    async connect(ctx: ExtensionContext, signal?: AbortSignal): Promise<void> {
+      signal?.throwIfAborted();
       shuttingDown = false;
 
       const socket = new SlackSocketModeClient({
@@ -565,7 +566,18 @@ export function createSinglePlayerRuntime(deps: SinglePlayerRuntimeDeps): Single
       });
 
       slackSocket = socket;
-      await socket.connect();
+      const abortConnect = () => {
+        void socket.disconnect().catch(() => {
+          /* connect owns the startup failure */
+        });
+      };
+      signal?.addEventListener("abort", abortConnect, { once: true });
+      try {
+        await socket.connect();
+        signal?.throwIfAborted();
+      } finally {
+        signal?.removeEventListener("abort", abortConnect);
+      }
     },
 
     async disconnect(): Promise<void> {

--- a/slack-bridge/slack-access-client.test.ts
+++ b/slack-bridge/slack-access-client.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SlackSocketModeClient, type SlackCall } from "./slack-access.js";
+
+class FakeWebSocket {
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+  static readonly instances: FakeWebSocket[] = [];
+  readonly close = vi.fn(() => {
+    this.readyState = FakeWebSocket.CLOSED;
+  });
+  readonly send = vi.fn();
+  readyState = FakeWebSocket.OPEN;
+
+  constructor() {
+    FakeWebSocket.instances.push(this);
+  }
+
+  addEventListener(): void {}
+}
+
+afterEach(() => {
+  FakeWebSocket.instances.length = 0;
+  vi.unstubAllGlobals();
+});
+
+describe("SlackSocketModeClient startup", () => {
+  it("requests bot identity and a Socket Mode URL concurrently", async () => {
+    type SlackResponse = Awaited<ReturnType<SlackCall>>;
+    let resolveAuth!: (value: SlackResponse) => void;
+    let resolveSocket!: (value: SlackResponse) => void;
+    const authResponse = new Promise<SlackResponse>((resolve) => {
+      resolveAuth = resolve;
+    });
+    const socketResponse = new Promise<SlackResponse>((resolve) => {
+      resolveSocket = resolve;
+    });
+    const slack = vi.fn<SlackCall>((method) => {
+      if (method === "auth.test") return authResponse;
+      if (method === "apps.connections.open") return socketResponse;
+      throw new Error(`Unexpected Slack method: ${method}`);
+    });
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+
+    const client = new SlackSocketModeClient({
+      slack,
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+    });
+    const connecting = client.connect();
+
+    await vi.waitFor(() => {
+      expect(slack).toHaveBeenCalledWith("auth.test", "xoxb-test");
+      expect(slack).toHaveBeenCalledWith("apps.connections.open", "xapp-test");
+    });
+
+    resolveSocket({ url: "wss://slack.example/socket" });
+    await Promise.resolve();
+    expect(FakeWebSocket.instances).toHaveLength(0);
+
+    resolveAuth({ user_id: "U_BOT" });
+    await connecting;
+
+    expect(client.getBotUserId()).toBe("U_BOT");
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+});

--- a/slack-bridge/slack-access-client.test.ts
+++ b/slack-bridge/slack-access-client.test.ts
@@ -54,9 +54,6 @@ describe("SlackSocketModeClient startup", () => {
     });
 
     resolveSocket({ url: "wss://slack.example/socket" });
-    await Promise.resolve();
-    expect(FakeWebSocket.instances).toHaveLength(0);
-
     resolveAuth({ user_id: "U_BOT" });
     await connecting;
 

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -585,9 +585,7 @@ export class SlackSocketModeClient {
         ? this.config.slack("auth.test", this.config.botToken)
         : Promise.resolve(null);
     const socketResponsePromise = this.config.slack("apps.connections.open", this.config.appToken);
-    void socketResponsePromise.catch(() => {
-      /* connectSocketMode owns connection failures after auth resolves */
-    });
+    void socketResponsePromise.catch(() => undefined);
 
     try {
       const auth = await authPromise;

--- a/slack-bridge/slack-access.ts
+++ b/slack-bridge/slack-access.ts
@@ -580,11 +580,27 @@ export class SlackSocketModeClient {
 
   async connect(): Promise<void> {
     this.shuttingDown = false;
-    if (this.config.resolveBotUserIdOnConnect ?? true) {
-      const auth = await this.config.slack("auth.test", this.config.botToken);
-      this.botUserId = typeof auth.user_id === "string" ? auth.user_id : null;
+    const authPromise =
+      (this.config.resolveBotUserIdOnConnect ?? true)
+        ? this.config.slack("auth.test", this.config.botToken)
+        : Promise.resolve(null);
+    const socketResponsePromise = this.config.slack("apps.connections.open", this.config.appToken);
+    void socketResponsePromise.catch(() => {
+      /* connectSocketMode owns connection failures after auth resolves */
+    });
+
+    try {
+      const auth = await authPromise;
+      if (auth) {
+        this.botUserId = typeof auth.user_id === "string" ? auth.user_id : null;
+      }
+      await this.connectSocketMode(socketResponsePromise);
+    } catch (error) {
+      await this.disconnect().catch(() => {
+        /* preserve the connection error */
+      });
+      throw error;
     }
-    await this.connectSocketMode();
   }
 
   async disconnect(): Promise<void> {
@@ -604,13 +620,14 @@ export class SlackSocketModeClient {
     await this.config.abortAndWait?.();
   }
 
-  private async connectSocketMode(): Promise<void> {
+  private async connectSocketMode(pendingResponse?: ReturnType<SlackCall>): Promise<void> {
     if (this.shuttingDown || this.connecting) return;
 
     this.connecting = true;
     let shouldReconnect = false;
     try {
-      const response = await this.config.slack("apps.connections.open", this.config.appToken);
+      const response = await (pendingResponse ??
+        this.config.slack("apps.connections.open", this.config.appToken));
       if (this.shuttingDown) return;
 
       const previous = this.ws;

--- a/slack-bridge/tool-output-limits.test.ts
+++ b/slack-bridge/tool-output-limits.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MAX_OUTPUT_BYTES,
+  DEFAULT_MAX_OUTPUT_LINES,
+  formatOutputSize,
+  measureHeadTruncation,
+} from "./tool-output-limits.js";
+
+describe("tool output limits", () => {
+  it("keeps output at both limits inline", () => {
+    const content = `${"a".repeat(DEFAULT_MAX_OUTPUT_BYTES - 1)}\n`;
+
+    expect(measureHeadTruncation(content)).toEqual({
+      truncated: false,
+      totalLines: 1,
+      totalBytes: DEFAULT_MAX_OUTPUT_BYTES,
+      outputLines: 1,
+      outputBytes: DEFAULT_MAX_OUTPUT_BYTES,
+    });
+  });
+
+  it("counts trailing newlines without creating a phantom line", () => {
+    expect(measureHeadTruncation("one\ntwo\n", { maxLines: 2, maxBytes: 7 })).toEqual({
+      truncated: true,
+      totalLines: 2,
+      totalBytes: 8,
+      outputLines: 2,
+      outputBytes: 7,
+    });
+  });
+
+  it("truncates on complete UTF-8 lines and reports original byte totals", () => {
+    expect(measureHeadTruncation("🙂\n🙂", { maxLines: 10, maxBytes: 5 })).toEqual({
+      truncated: true,
+      totalLines: 2,
+      totalBytes: 9,
+      outputLines: 1,
+      outputBytes: 4,
+    });
+  });
+
+  it("enforces the default line limit independently of bytes", () => {
+    const content = Array.from({ length: DEFAULT_MAX_OUTPUT_LINES + 1 }, () => "x").join("\n");
+    const result = measureHeadTruncation(content);
+
+    expect(result.truncated).toBe(true);
+    expect(result.totalLines).toBe(DEFAULT_MAX_OUTPUT_LINES + 1);
+    expect(result.outputLines).toBe(DEFAULT_MAX_OUTPUT_LINES);
+  });
+
+  it("formats byte sizes for spill notices", () => {
+    expect(formatOutputSize(512)).toBe("512B");
+    expect(formatOutputSize(1_536)).toBe("1.5KB");
+    expect(formatOutputSize(2 * 1_024 * 1_024)).toBe("2.0MB");
+  });
+});

--- a/slack-bridge/tool-output-limits.test.ts
+++ b/slack-bridge/tool-output-limits.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  DEFAULT_MAX_OUTPUT_BYTES,
   DEFAULT_MAX_OUTPUT_LINES,
   formatOutputSize,
   measureHeadTruncation,
@@ -8,14 +7,12 @@ import {
 
 describe("tool output limits", () => {
   it("keeps output at both limits inline", () => {
-    const content = `${"a".repeat(DEFAULT_MAX_OUTPUT_BYTES - 1)}\n`;
-
-    expect(measureHeadTruncation(content)).toEqual({
+    expect(measureHeadTruncation("a\nb", { maxLines: 2, maxBytes: 3 })).toEqual({
       truncated: false,
-      totalLines: 1,
-      totalBytes: DEFAULT_MAX_OUTPUT_BYTES,
-      outputLines: 1,
-      outputBytes: DEFAULT_MAX_OUTPUT_BYTES,
+      totalLines: 2,
+      totalBytes: 3,
+      outputLines: 2,
+      outputBytes: 3,
     });
   });
 

--- a/slack-bridge/tool-output-limits.ts
+++ b/slack-bridge/tool-output-limits.ts
@@ -1,0 +1,56 @@
+export const DEFAULT_MAX_OUTPUT_LINES = 2_000;
+export const DEFAULT_MAX_OUTPUT_BYTES = 50 * 1_024;
+
+export interface HeadTruncation {
+  truncated: boolean;
+  totalLines: number;
+  totalBytes: number;
+  outputLines: number;
+  outputBytes: number;
+}
+
+export function formatOutputSize(bytes: number): string {
+  if (bytes < 1_024) return `${bytes}B`;
+  if (bytes < 1_024 * 1_024) return `${(bytes / 1_024).toFixed(1)}KB`;
+  return `${(bytes / (1_024 * 1_024)).toFixed(1)}MB`;
+}
+
+export function measureHeadTruncation(
+  content: string,
+  options: { maxLines?: number; maxBytes?: number } = {},
+): HeadTruncation {
+  const maxLines = options.maxLines ?? DEFAULT_MAX_OUTPUT_LINES;
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+  const lines = content.length === 0 ? [] : content.split("\n");
+  if (content.endsWith("\n")) lines.pop();
+
+  const totalLines = lines.length;
+  const totalBytes = Buffer.byteLength(content, "utf8");
+  if (totalLines <= maxLines && totalBytes <= maxBytes) {
+    return {
+      truncated: false,
+      totalLines,
+      totalBytes,
+      outputLines: totalLines,
+      outputBytes: totalBytes,
+    };
+  }
+
+  const outputLines: string[] = [];
+  let outputBytes = 0;
+  for (let index = 0; index < lines.length && index < maxLines; index += 1) {
+    const line = lines[index];
+    const lineBytes = Buffer.byteLength(line, "utf8") + (index > 0 ? 1 : 0);
+    if (outputBytes + lineBytes > maxBytes) break;
+    outputLines.push(line);
+    outputBytes += lineBytes;
+  }
+
+  return {
+    truncated: true,
+    totalLines,
+    totalBytes,
+    outputLines: outputLines.length,
+    outputBytes: Buffer.byteLength(outputLines.join("\n"), "utf8"),
+  };
+}


### PR DESCRIPTION
## Summary
- load the built Slack bridge entry instead of transpiling TypeScript at every Pi startup
- remove the eager runtime import of the Pi coding-agent package from Pinet tools
- return from `session_start` before Git/SQLite/Slack/Pinet connection work finishes, while keeping managed tools inactive until ready
- make pending single, follower, and broker starts abortable so shutdown and mode changes cannot deadlock behind startup
- request Slack auth and Socket Mode URL concurrently while gating WebSocket activation on bot identity
- bound and cancel startup Git metadata probes and harden request-generation resets

## Measured impact
- full local Pi startup: **3.87s → 3.13–3.16s** in the final warm benchmark (~19% faster)
- isolated extension load: source **1.55s** vs built entry **0.99s** (same **0.72s** baseline)
- earlier colder full-startup sample: **6.26s → 3.61–4.00s**

## Verification
- Slack bridge: **1,708 passed**, 3 skipped
- all workspace tests and script tests: passed
- Slack bridge typecheck and Oxlint: passed
- agent standards lint: passed
- Prettier and `git diff --check`: passed
- targeted regressions cover nonblocking startup, pending follower shutdown, broker adapter cancellation/cleanup, pending broker socket cancellation, abortable Git probes, and Slack connection concurrency

## Known unrelated local check issue
The full `pnpm prepush` reaches an existing `neon-psql` TypeBox identity mismatch caused by duplicate dependency resolution across the main checkout and worktree. All changed-package checks and the full workspace test suite pass.