### PR TITLE
chore(release): prepare Pinet 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ themselves create a new release entry, tag, or package version. Add a versioned
 entry only when a maintainer approves a real release with intentional package
 version bumps and publish scope.
 
+## [0.2.6] - 2026-08-22
+
+Pinet v0.2.6 adds the standalone durable single-agent goal loop and tightens Slack bridge startup, mode boundaries, and dependency/release hygiene. It expands the coordinated npm release set to seven `@pinet/*` packages.
+
+### Version verification
+
+- `pi-extensions` — `0.2.6` (private repo package)
+- `@pinet/transport-core` — `0.2.6`
+- `@pinet/broker-core` — `0.2.6`
+- `@pinet/pinet-core` — `0.2.6`
+- `@pinet/imessage-bridge` — `0.2.6`
+- `@pinet/slack-bridge` — `0.2.6`
+- `@pinet/model-aware-compaction` — `0.2.6`
+- `@pinet/agent-goal` — `0.2.6` (initial release)
+
+### Release highlights
+
+- Adds `@pinet/agent-goal`, a standalone Pi extension for one durable, bounded goal per agent session. Agents can create and inspect goals, request independently evaluated completion or blocking decisions, and continue ordinary settled work without an evaluator call.
+- Persists goal state, terminal candidates, evaluator work, continuation claims, usage accounting, and recovery state through replaceable memory and SQLite adapters.
+- Adds bounded iteration, token, runtime, checkpoint, evaluator-retry, and continuation-retry policies with a Pi-native dashboard and headless command fallback.
+- Atomically preserves every settlement that arrives during in-flight evaluation and schedules process-local recovery for deferred or orphaned continuations without requiring Pinet, Slack, a broker, RALPH, tmux, subagents, or spawned Pi processes.
+- Gates Slack runtime guidance and tools by the active mode, reducing irrelevant prompt/tool surface outside Pinet operation.
+- Speeds up and simplifies Slack bridge startup while removing stale startup support and fixing a broker reload lifecycle test race.
+- Replaces ESLint with Oxlint across the workspace and delays newly released dependencies during automated updates.
+- Removes the obsolete browser Playwright extension from the repository.
+
+### Notable pull requests
+
+- [#990](https://github.com/gugu91/pinet/pull/990) — add the standalone single-agent goal loop
+- [#986](https://github.com/gugu91/pinet/pull/986) — fix the broker reload lifecycle test race
+- [#985](https://github.com/gugu91/pinet/pull/985) — simplify Slack bridge startup support
+- [#984](https://github.com/gugu91/pinet/pull/984) — speed up Slack bridge startup
+- [#981](https://github.com/gugu91/pinet/pull/981) — replace ESLint with Oxlint
+- [#980](https://github.com/gugu91/pinet/pull/980) — gate Slack runtime guidance and tools by mode
+- [#979](https://github.com/gugu91/pinet/pull/979) — remove the browser Playwright extension
+- [#977](https://github.com/gugu91/pinet/pull/977) — delay newly released dependencies
+
+See the [full change set since v0.2.5](https://github.com/gugu91/pinet/compare/v0.2.5...v0.2.6).
+
 ## [0.2.5] - 2026-07-30
 
 Pinet v0.2.5 adds Herdr-backed subtree workers, broker-managed hibernation and safer worker recovery. It keeps the coordinated `@pinet/*` package set aligned.

--- a/agent-goal/package.json
+++ b/agent-goal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/agent-goal",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "description": "Standalone single-agent durable goal loop for Pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/broker-core",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "description": "Transport-neutral broker kernel primitives for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/imessage-bridge",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "description": "macOS/iMessage send-first adapter and readiness helpers for pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/model-aware-compaction/package.json
+++ b/model-aware-compaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/model-aware-compaction",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "description": "Pi extension for proactive model-aware context compaction thresholds",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/pinet-core",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "description": "Pinet runtime core for pi — broker/follower orchestration and mesh tooling",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/plans/npm-publish.md
+++ b/plans/npm-publish.md
@@ -12,8 +12,9 @@ The publish workflow always validates or publishes the full npm org `pinet` pack
 4. `@pinet/imessage-bridge` from `imessage-bridge/`
 5. `@pinet/slack-bridge` from `slack-bridge/`
 6. `@pinet/model-aware-compaction` from `model-aware-compaction/`
+7. `@pinet/agent-goal` from `agent-goal/`
 
-There is intentionally no workflow target selector or script target flag. Real releases always attempt the shared core packages, bridges, and model-aware compaction package in dependency order so dependency versions stay aligned. npm publishes are sequential rather than atomic, so operators must verify the full package set after any real publish and treat a late failure as a partial-release recovery task.
+There is intentionally no workflow target selector or script target flag. Real releases always attempt the shared core packages, bridges, and standalone extensions in dependency order so dependency versions stay aligned. npm publishes are sequential rather than atomic, so operators must verify the full package set after any real publish and treat a late failure as a partial-release recovery task.
 
 ## Workflow and script
 
@@ -59,7 +60,7 @@ Manual real publishes require all of these gates before the publish job can run:
 
 Tag-triggered real publishes require all of these gates before the publish job can run:
 
-- A maintainer-approved version-bump PR has landed on `main`, with all six `@pinet/*` package versions and `pnpm-lock.yaml` aligned.
+- A maintainer-approved version-bump PR has landed on `main`, with all seven `@pinet/*` package versions aligned and a frozen-lockfile install succeeding.
 - A `vX.Y.Z` tag points at the current `main` tip after the version-bump PR merges.
 - The non-environment preflight job fetches `origin/main` and confirms the tag commit equals the current `origin/main` tip.
 - The same preflight job confirms every full-set package version equals `X.Y.Z`.
@@ -141,7 +142,7 @@ GitHub permissions:
 
 - #772 has confirmed the Pinet/Slack boundary and the full publish set is still correct.
 - Package versions are intentionally bumped together. The publish and bootstrap scripts refuse real publishes for placeholder `0.0.0` packages or versions already present on npm.
-- `pnpm-lock.yaml` is updated for the package-version bump.
+- `pnpm-lock.yaml` is updated when dependency or workspace specifiers change; a version-only bump may leave it unchanged, but `pnpm install --frozen-lockfile` must succeed.
 - `CHANGELOG.md` has a maintainer-approved entry covering the full package set and package versions.
 - The dry-run/readiness job is green on the same `main` commit intended for release.
 - For manual real publishes, the workflow dispatch includes the exact `publish all` release approval phrase and runs from `main`.

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/slack-bridge",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "description": "Pi package for Pinet Slack assistant integration — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/transport-core",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "description": "Transport-neutral message contracts for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
Closes #991.

## Summary
- bump the private root and all seven coordinated `@pinet/*` packages to `0.2.6`
- add the v0.2.6 changelog, including the initial `@pinet/agent-goal` release
- update npm publication docs for the seven-package set and version-only lockfile behavior
- retire the stale waiting v0.2.5 publish workflow that targeted the older package set

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm prepush`
- `pnpm publish:npm` (all seven packages, dry-run only)
- `node scripts/validate-npm-tag-version.mjs refs/tags/v0.2.6`
- `git diff --check`
- fresh subagent release review: no blockers

## Release safety
This PR does not tag or publish. After merge, run the protected GitHub npm dry-run on the exact `main` commit. A live publish still requires separate explicit approval, the `npm-publish` environment approval, and either Trusted Publishing configured for all seven packages or the documented guarded bootstrap path for the new `@pinet/agent-goal` package.