### PR TITLE
feat(agent-goal): add minimal goal window

### DIFF
--- a/agent-goal/README.md
+++ b/agent-goal/README.md
@@ -20,7 +20,7 @@ pi -e ./agent-goal/index.ts
 
 ```text
 /goal <objective>  Create and immediately start a goal
-/goal              Inspect this session's goal
+/goal              Open the minimal goal window (text in headless modes)
 /goal pause        Pause automatic evaluation and continuation
 /goal resume       Resume and immediately continue
 /goal complete     Mark complete manually
@@ -29,7 +29,7 @@ pi -e ./agent-goal/index.ts
 /goal show         Show the persistent goal dashboard
 ```
 
-Pi's footer shows the status and budget usage. A compact widget below the editor shows the objective, turns, tokens, last evaluator decision, continuation state, and available commands. `/goal` remains a textual fallback in headless sessions.
+Pi's footer shows the status and budget usage. A compact widget below the editor shows passive progress. In interactive mode, `/goal` opens a centered, keyboard-dismissable window with the objective, lifecycle state, budget bars, latest evaluator guidance, and continuation state. Press Escape, Enter, `q`, or Ctrl+C to close it. `/goal` remains a textual fallback in headless sessions.
 
 Only one goal may exist per Pi session. Clear the existing goal before creating another.
 

--- a/agent-goal/dashboard.ts
+++ b/agent-goal/dashboard.ts
@@ -1,6 +1,6 @@
 import type { AgentGoal, GoalContinuationClaim } from "./domain.js";
 
-function displayText(value: string, maxLength: number): string {
+export function displayGoalText(value: string, maxLength: number): string {
   const normalized = value
     .replaceAll("\n", " ")
     .replaceAll("\r", " ")
@@ -31,15 +31,15 @@ export function formatGoalDashboard(goal: AgentGoal, claim?: GoalContinuationCla
     .join(" · ");
   const lines = [
     `Goal · ${goal.status} · v${goal.version}`,
-    displayText(goal.objective, 120),
+    displayGoalText(goal.objective, 120),
     usage,
   ];
   if (goal.lastEvaluation) {
     lines.push(
-      `Last ${goal.lastEvaluation.outcome.toUpperCase()}: ${displayText(goal.lastEvaluation.reason, 100)}`,
+      `Last ${goal.lastEvaluation.outcome.toUpperCase()}: ${displayGoalText(goal.lastEvaluation.reason, 100)}`,
     );
   }
-  if (goal.blockedReason) lines.push(`Reason: ${displayText(goal.blockedReason, 100)}`);
+  if (goal.blockedReason) lines.push(`Reason: ${displayGoalText(goal.blockedReason, 100)}`);
   if (claim) lines.push(`Continuation: ${claim.state} · attempt ${claim.attempt}`);
   lines.push("/goal pause · resume · complete · clear · hide");
   return lines;

--- a/agent-goal/goal-window.test.ts
+++ b/agent-goal/goal-window.test.ts
@@ -1,0 +1,88 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentGoal, GoalContinuationClaim } from "./domain.js";
+import { GoalWindow } from "./goal-window.js";
+
+const theme = {
+  fg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+} as Theme;
+
+const goal: AgentGoal = {
+  id: "goal-1",
+  scopeId: "session-1",
+  objective:
+    "Ship a focused goal window that remains readable even when the objective is longer than one line.",
+  status: "active",
+  budget: { maxIterations: 8, maxTokens: 50_000, maxRuntimeMs: 3_600_000 },
+  usage: { iterations: 3, tokens: 12_430 },
+  lastEvaluation: {
+    id: "evaluation-1",
+    outcome: "continue",
+    reason: "Interaction tests remain",
+    at: "2026-01-01T00:10:00.000Z",
+  },
+  version: 4,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:10:00.000Z",
+};
+
+const claim: GoalContinuationClaim = {
+  scopeId: "session-1",
+  goalId: "goal-1",
+  goalVersion: 4,
+  claimId: "claim-1",
+  state: "deferred",
+  reason: "session busy",
+  attempt: 2,
+  availableAt: "2026-01-01T00:10:01.000Z",
+  expiresAt: "2026-01-01T00:11:00.000Z",
+  createdAt: "2026-01-01T00:10:00.000Z",
+  updatedAt: "2026-01-01T00:10:00.000Z",
+};
+
+describe("GoalWindow", () => {
+  it("renders compact goal state and keeps every line within the available width", () => {
+    const window = new GoalWindow(goal, claim, theme, vi.fn(), () =>
+      Date.parse("2026-01-01T00:15:00.000Z"),
+    );
+
+    const lines = window.render(52);
+
+    expect(lines.join("\n")).toContain("● ACTIVE");
+    expect(lines.join("\n")).toContain("Turns");
+    expect(lines.join("\n")).toContain("3/8");
+    expect(lines.join("\n")).toContain("12.4k/50k");
+    expect(lines.join("\n")).toContain("15m/60m");
+    expect(lines.join("\n")).toContain("Latest Interaction tests remain");
+    expect(lines.join("\n")).toContain("Continuation deferred · attempt 2");
+    expect(lines.every((line) => visibleWidth(line) <= 52)).toBe(true);
+  });
+
+  it("renders a useful empty state", () => {
+    const lines = new GoalWindow(undefined, undefined, theme, vi.fn()).render(40);
+
+    expect(lines.join("\n")).toContain("No goal for this session.");
+    expect(lines.join("\n")).toContain("/goal <objective> to begin");
+    expect(lines.every((line) => visibleWidth(line) <= 40)).toBe(true);
+  });
+
+  it.each(["q", "Q", "\u001b", "\r", "\u0003"])("closes for %j", (input) => {
+    const onClose = vi.fn();
+    const window = new GoalWindow(goal, undefined, theme, onClose);
+
+    window.handleInput(input);
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("ignores unrelated input", () => {
+    const onClose = vi.fn();
+    const window = new GoalWindow(goal, undefined, theme, onClose);
+
+    window.handleInput("x");
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/agent-goal/goal-window.test.ts
+++ b/agent-goal/goal-window.test.ts
@@ -68,6 +68,15 @@ describe("GoalWindow", () => {
     expect(lines.every((line) => visibleWidth(line) <= 40)).toBe(true);
   });
 
+  it.each([0, 1, 2, 3, 4, 5, 6, 7])(
+    "honors the strict line-width contract at width %i",
+    (width) => {
+      const lines = new GoalWindow(goal, claim, theme, vi.fn()).render(width);
+
+      expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+    },
+  );
+
   it.each(["q", "Q", "\u001b", "\r", "\u0003"])("closes for %j", (input) => {
     const onClose = vi.fn();
     const window = new GoalWindow(goal, undefined, theme, onClose);

--- a/agent-goal/goal-window.ts
+++ b/agent-goal/goal-window.ts
@@ -44,7 +44,7 @@ export class GoalWindow implements Component {
   }
 
   render(width: number): string[] {
-    if (width < 4) return [truncateToWidth("Goal", Math.max(0, width), "")];
+    if (width < 8) return [truncateToWidth("Goal", Math.max(0, width), "")];
     const innerWidth = width - 2;
     const contentWidth = Math.max(1, innerWidth - 2);
     const borderColor = this.goal?.status === "complete" ? "success" : "borderAccent";

--- a/agent-goal/goal-window.ts
+++ b/agent-goal/goal-window.ts
@@ -1,0 +1,157 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import {
+  matchesKey,
+  truncateToWidth,
+  visibleWidth,
+  wrapTextWithAnsi,
+  type Component,
+} from "@earendil-works/pi-tui";
+import { displayGoalText } from "./dashboard.js";
+import type { AgentGoal, GoalContinuationClaim } from "./domain.js";
+
+function progressBar(value: number, maximum: number, width: number): string {
+  const ratio = Math.min(1, Math.max(0, value / maximum));
+  const filled = Math.round(ratio * width);
+  return `${"━".repeat(filled)}${"─".repeat(width - filled)}`;
+}
+
+function compactNumber(value: number): string {
+  if (value < 1_000) return String(value);
+  const divisor = value < 1_000_000 ? 1_000 : 1_000_000;
+  const suffix = value < 1_000_000 ? "k" : "m";
+  const scaled = value / divisor;
+  return `${scaled.toFixed(scaled < 100 ? 1 : 0).replace(/\.0$/, "")}${suffix}`;
+}
+
+export class GoalWindow implements Component {
+  constructor(
+    private readonly goal: AgentGoal | undefined,
+    private readonly claim: GoalContinuationClaim | undefined,
+    private readonly theme: Theme,
+    private readonly onClose: () => void,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  handleInput(data: string): void {
+    if (
+      matchesKey(data, "escape") ||
+      matchesKey(data, "ctrl+c") ||
+      matchesKey(data, "return") ||
+      data.toLowerCase() === "q"
+    ) {
+      this.onClose();
+    }
+  }
+
+  render(width: number): string[] {
+    if (width < 4) return [truncateToWidth("Goal", Math.max(0, width), "")];
+    const innerWidth = width - 2;
+    const contentWidth = Math.max(1, innerWidth - 2);
+    const borderColor = this.goal?.status === "complete" ? "success" : "borderAccent";
+    const border = (text: string): string => this.theme.fg(borderColor, text);
+    const row = (content = ""): string => {
+      const truncated = truncateToWidth(content, innerWidth, "", true);
+      return `${border("│")}${truncated}${" ".repeat(Math.max(0, innerWidth - visibleWidth(truncated)))}${border("│")}`;
+    };
+    const title = this.theme.fg("accent", this.theme.bold(" Goal "));
+    const titleWidth = visibleWidth(title);
+    const lines = [
+      `${border("╭")}${title}${border(`${"─".repeat(Math.max(0, innerWidth - titleWidth))}╮`)}`,
+    ];
+
+    if (!this.goal) {
+      lines.push(row(), row(` ${this.theme.fg("muted", "No goal for this session.")}`));
+      lines.push(row(` ${this.theme.fg("dim", "/goal <objective> to begin")}`), row());
+      lines.push(row(` ${this.theme.fg("dim", "esc · enter · q  close")}`));
+      lines.push(border(`╰${"─".repeat(innerWidth)}╯`));
+      return lines;
+    }
+
+    const statusColor =
+      this.goal.status === "complete"
+        ? "success"
+        : this.goal.status === "blocked"
+          ? "error"
+          : this.goal.status === "active"
+            ? "accent"
+            : "warning";
+    lines.push(row(` ${this.theme.fg(statusColor, `● ${this.goal.status.toUpperCase()}`)}`));
+
+    const objectiveLines = wrapTextWithAnsi(
+      displayGoalText(this.goal.objective, 500),
+      contentWidth,
+    ).slice(0, 3);
+    for (const objectiveLine of objectiveLines) lines.push(row(` ${objectiveLine}`));
+    lines.push(row());
+
+    const turnBar = progressBar(
+      this.goal.usage.iterations,
+      this.goal.budget.maxIterations,
+      Math.min(12, Math.max(4, contentWidth - 23)),
+    );
+    lines.push(
+      row(
+        ` Turns  ${this.theme.fg("accent", turnBar)}  ${this.goal.usage.iterations}/${this.goal.budget.maxIterations}`,
+      ),
+    );
+
+    if (this.goal.budget.maxTokens === undefined) {
+      lines.push(row(` Tokens ${compactNumber(this.goal.usage.tokens)}`));
+    } else {
+      const tokenBar = progressBar(
+        this.goal.usage.tokens,
+        this.goal.budget.maxTokens,
+        Math.min(12, Math.max(4, contentWidth - 23)),
+      );
+      lines.push(
+        row(
+          ` Tokens ${this.theme.fg("accent", tokenBar)}  ${compactNumber(this.goal.usage.tokens)}/${compactNumber(this.goal.budget.maxTokens)}`,
+        ),
+      );
+    }
+
+    if (this.goal.budget.maxRuntimeMs !== undefined) {
+      const end = this.goal.status === "active" ? this.now() : Date.parse(this.goal.updatedAt);
+      const elapsed = Math.max(0, end - Date.parse(this.goal.createdAt));
+      const runtimeBar = progressBar(
+        elapsed,
+        this.goal.budget.maxRuntimeMs,
+        Math.min(12, Math.max(4, contentWidth - 23)),
+      );
+      lines.push(
+        row(
+          ` Time   ${this.theme.fg("accent", runtimeBar)}  ${Math.floor(elapsed / 60_000)}m/${Math.ceil(this.goal.budget.maxRuntimeMs / 60_000)}m`,
+        ),
+      );
+    }
+
+    if (this.goal.lastEvaluation) {
+      lines.push(
+        row(),
+        row(
+          ` ${this.theme.fg("muted", "Latest")} ${displayGoalText(this.goal.lastEvaluation.reason, Math.max(20, contentWidth - 8))}`,
+        ),
+      );
+    } else if (this.goal.blockedReason) {
+      lines.push(
+        row(),
+        row(
+          ` ${this.theme.fg("muted", "Reason")} ${displayGoalText(this.goal.blockedReason, Math.max(20, contentWidth - 8))}`,
+        ),
+      );
+    }
+    if (this.claim) {
+      lines.push(
+        row(
+          ` ${this.theme.fg("muted", "Continuation")} ${this.claim.state} · attempt ${this.claim.attempt}`,
+        ),
+      );
+    }
+
+    lines.push(row(), row(` ${this.theme.fg("dim", "esc · enter · q  close")}`));
+    lines.push(border(`╰${"─".repeat(innerWidth)}╯`));
+    return lines;
+  }
+
+  invalidate(): void {}
+}

--- a/agent-goal/index.test.ts
+++ b/agent-goal/index.test.ts
@@ -1,5 +1,6 @@
 import type {
   ExtensionAPI,
+  ExtensionCommandContext,
   ExtensionContext,
   ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
@@ -12,6 +13,7 @@ type GoalEventHandler = (
   event: { messages?: GoalProgressMessage[] },
   context: ExtensionContext,
 ) => Promise<void> | void;
+type RegisteredCommand = Parameters<ExtensionAPI["registerCommand"]>[1];
 
 afterEach(() => vi.useRealTimers());
 
@@ -140,6 +142,59 @@ describe("registerAgentGoal", () => {
     expect(sendMessage).toHaveBeenCalledOnce();
     expect(await storage.getContinuationClaim("session-1")).toMatchObject({ state: "started" });
     await handlers.get("session_shutdown")?.({}, context);
+  });
+
+  it("opens a goal overlay in TUI mode and preserves the textual fallback", async () => {
+    const commands = new Map<string, RegisteredCommand>();
+    const sendMessage = vi.fn();
+    const pi = {
+      on: vi.fn(),
+      registerTool: vi.fn(),
+      registerCommand(name: string, command: RegisteredCommand) {
+        commands.set(name, command);
+      },
+      sendMessage,
+    } as object as ExtensionAPI;
+    const custom = vi.fn().mockResolvedValue(undefined);
+    const baseContext = {
+      hasUI: true,
+      isIdle: () => true,
+      hasPendingMessages: () => false,
+      sessionManager: { getSessionId: () => "session-1" },
+      ui: {
+        custom,
+        setStatus: vi.fn(),
+        setWidget: vi.fn(),
+        notify: vi.fn(),
+      },
+    };
+    registerAgentGoal(pi, { storage: new MemoryGoalStorage() });
+    const command = commands.get("goal");
+    if (!command) throw new Error("goal command was not registered");
+
+    await command.handler("", {
+      ...baseContext,
+      mode: "tui",
+    } as object as ExtensionCommandContext);
+
+    expect(custom).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        overlay: true,
+        overlayOptions: expect.objectContaining({ anchor: "center" }),
+      }),
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    await command.handler("", {
+      ...baseContext,
+      mode: "print",
+    } as object as ExtensionCommandContext);
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "This session has no goal." }),
+      { triggerTurn: false },
+    );
   });
 
   it("lets the worker create and inspect its own bounded goal", async () => {

--- a/agent-goal/index.test.ts
+++ b/agent-goal/index.test.ts
@@ -2,8 +2,10 @@ import type {
   ExtensionAPI,
   ExtensionCommandContext,
   ExtensionContext,
+  Theme,
   ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GoalProgressMessage } from "./progress.js";
 import { registerAgentGoal } from "./index.js";
@@ -14,6 +16,12 @@ type GoalEventHandler = (
   context: ExtensionContext,
 ) => Promise<void> | void;
 type RegisteredCommand = Parameters<ExtensionAPI["registerCommand"]>[1];
+type GoalWindowFactory = (
+  tui: { requestRender(): void },
+  theme: Theme,
+  keybindings: object,
+  done: (value: void) => void,
+) => Component;
 
 afterEach(() => vi.useRealTimers());
 
@@ -155,8 +163,15 @@ describe("registerAgentGoal", () => {
       },
       sendMessage,
     } as object as ExtensionAPI;
-    const custom = vi.fn().mockResolvedValue(undefined);
-    const baseContext = {
+    const custom = vi.fn(async (factory: GoalWindowFactory) => {
+      factory(
+        { requestRender: vi.fn() },
+        { fg: (_color, text) => text, bold: (text) => text } as Theme,
+        {},
+        vi.fn(),
+      );
+    });
+    const context = {
       hasUI: true,
       isIdle: () => true,
       hasPendingMessages: () => false,
@@ -167,15 +182,12 @@ describe("registerAgentGoal", () => {
         setWidget: vi.fn(),
         notify: vi.fn(),
       },
-    };
+    } as object as ExtensionCommandContext;
     registerAgentGoal(pi, { storage: new MemoryGoalStorage() });
     const command = commands.get("goal");
     if (!command) throw new Error("goal command was not registered");
 
-    await command.handler("", {
-      ...baseContext,
-      mode: "tui",
-    } as object as ExtensionCommandContext);
+    await command.handler("", context);
 
     expect(custom).toHaveBeenCalledWith(
       expect.any(Function),
@@ -186,15 +198,11 @@ describe("registerAgentGoal", () => {
     );
     expect(sendMessage).not.toHaveBeenCalled();
 
-    for (const mode of ["print", "rpc", "json"] as const) {
-      await command.handler("", {
-        ...baseContext,
-        mode,
-      } as object as ExtensionCommandContext);
-    }
+    custom.mockImplementation(async () => undefined);
+    await command.handler("", context);
 
-    expect(sendMessage).toHaveBeenCalledTimes(3);
-    expect(sendMessage).toHaveBeenLastCalledWith(
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({ content: "This session has no goal." }),
       { triggerTurn: false },
     );

--- a/agent-goal/index.test.ts
+++ b/agent-goal/index.test.ts
@@ -186,12 +186,15 @@ describe("registerAgentGoal", () => {
     );
     expect(sendMessage).not.toHaveBeenCalled();
 
-    await command.handler("", {
-      ...baseContext,
-      mode: "print",
-    } as object as ExtensionCommandContext);
+    for (const mode of ["print", "rpc", "json"] as const) {
+      await command.handler("", {
+        ...baseContext,
+        mode,
+      } as object as ExtensionCommandContext);
+    }
 
-    expect(sendMessage).toHaveBeenCalledWith(
+    expect(sendMessage).toHaveBeenCalledTimes(3);
+    expect(sendMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({ content: "This session has no goal." }),
       { triggerTurn: false },
     );

--- a/agent-goal/index.ts
+++ b/agent-goal/index.ts
@@ -2,6 +2,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { formatGoalDashboard, formatGoalStatus } from "./dashboard.js";
+import { GoalWindow } from "./goal-window.js";
 import type {
   GoalBudget,
   GoalContinuation,
@@ -42,7 +43,8 @@ export type {
   GoalUsage,
   GoalWakeScheduler,
 } from "./domain.js";
-export { formatGoalDashboard, formatGoalStatus } from "./dashboard.js";
+export { displayGoalText, formatGoalDashboard, formatGoalStatus } from "./dashboard.js";
+export { GoalWindow } from "./goal-window.js";
 export { MemoryGoalStorage } from "./memory-storage.js";
 export { parseGoalEvaluation, PiGoalEvaluator } from "./pi-evaluator.js";
 export {
@@ -398,16 +400,33 @@ export function registerAgentGoal(pi: ExtensionAPI, options: AgentGoalExtensionO
         if (!input) {
           const goal = await runtime.get(scopeId);
           const claim = await runtime.getContinuationClaim(scopeId);
-          api.sendMessage(
-            {
-              customType: "agent-goal.status",
-              content: goal
-                ? formatGoalDashboard(goal, claim).join("\n")
-                : "This session has no goal.",
-              display: true,
-            },
-            { triggerTurn: false },
-          );
+          if (ctx.mode === "tui") {
+            await ctx.ui.custom<void>(
+              (_tui, theme, _keybindings, done) =>
+                new GoalWindow(goal, claim, theme, () => done(undefined)),
+              {
+                overlay: true,
+                overlayOptions: {
+                  anchor: "center",
+                  width: 66,
+                  minWidth: 36,
+                  maxHeight: "80%",
+                  margin: 1,
+                },
+              },
+            );
+          } else {
+            api.sendMessage(
+              {
+                customType: "agent-goal.status",
+                content: goal
+                  ? formatGoalDashboard(goal, claim).join("\n")
+                  : "This session has no goal.",
+                display: true,
+              },
+              { triggerTurn: false },
+            );
+          }
           return;
         }
 

--- a/agent-goal/index.ts
+++ b/agent-goal/index.ts
@@ -400,33 +400,35 @@ export function registerAgentGoal(pi: ExtensionAPI, options: AgentGoalExtensionO
         if (!input) {
           const goal = await runtime.get(scopeId);
           const claim = await runtime.getContinuationClaim(scopeId);
-          if (ctx.mode === "tui") {
-            await ctx.ui.custom<void>(
-              (_tui, theme, _keybindings, done) =>
-                new GoalWindow(goal, claim, theme, () => done(undefined)),
-              {
-                overlay: true,
-                overlayOptions: {
-                  anchor: "center",
-                  width: 66,
-                  minWidth: 36,
-                  maxHeight: "80%",
-                  margin: 1,
-                },
+          let openedWindow = false;
+          await ctx.ui.custom<void>(
+            (_tui, theme, _keybindings, done) => {
+              openedWindow = true;
+              return new GoalWindow(goal, claim, theme, () => done(undefined));
+            },
+            {
+              overlay: true,
+              overlayOptions: {
+                anchor: "center",
+                width: 66,
+                minWidth: 36,
+                maxHeight: "80%",
+                margin: 1,
               },
-            );
-          } else {
-            api.sendMessage(
-              {
-                customType: "agent-goal.status",
-                content: goal
-                  ? formatGoalDashboard(goal, claim).join("\n")
-                  : "This session has no goal.",
-                display: true,
-              },
-              { triggerTurn: false },
-            );
-          }
+            },
+          );
+          if (openedWindow) return;
+
+          api.sendMessage(
+            {
+              customType: "agent-goal.status",
+              content: goal
+                ? formatGoalDashboard(goal, claim).join("\n")
+                : "This session has no goal.",
+              display: true,
+            },
+            { triggerTurn: false },
+          );
           return;
         }
 

--- a/agent-goal/package.json
+++ b/agent-goal/package.json
@@ -48,6 +48,7 @@
   "dependencies": {},
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.74.0",
-    "@earendil-works/pi-coding-agent": ">=0.74.0"
+    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-tui": ">=0.74.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       "@earendil-works/pi-coding-agent":
         specifier: ">=0.74.0"
         version: 0.74.0(ws@8.20.0)(zod@4.3.6)
+      "@earendil-works/pi-tui":
+        specifier: ">=0.74.0"
+        version: 0.74.0
 
   broker-core:
     dependencies:

--- a/types/pi-coding-agent.d.ts
+++ b/types/pi-coding-agent.d.ts
@@ -18,10 +18,33 @@ declare module "@earendil-works/pi-coding-agent" {
     options: { maxLines: number; maxBytes: number },
   ): TruncationResult;
 
+  export interface Theme {
+    fg(color: string, text: string): string;
+    bold(text: string): string;
+  }
+
   export interface ExtensionUI {
     theme: any;
     notify(message: string, level?: string): void;
     setStatus(id: string, value?: any): void;
+    custom<T>(
+      factory: (
+        tui: { requestRender(): void },
+        theme: Theme,
+        keybindings: object,
+        done: (value: T) => void,
+      ) => import("@earendil-works/pi-tui").Component,
+      options?: {
+        overlay?: boolean;
+        overlayOptions?: {
+          anchor?: string;
+          width?: number | `${number}%`;
+          minWidth?: number;
+          maxHeight?: number | `${number}%`;
+          margin?: number;
+        };
+      },
+    ): Promise<T>;
   }
 
   export interface SessionEntry {
@@ -40,6 +63,7 @@ declare module "@earendil-works/pi-coding-agent" {
 
   export interface ExtensionContext {
     cwd: string;
+    mode?: "tui" | "rpc" | "json" | "print";
     hasUI?: boolean;
     isIdle?: () => boolean;
     ui: ExtensionUI;
@@ -78,9 +102,11 @@ declare module "@earendil-works/pi-coding-agent" {
     renderResult?: (result: any, options: any, theme: any) => any;
   }
 
+  export interface ExtensionCommandContext extends ExtensionContext {}
+
   export interface CommandDefinition {
     description?: string;
-    handler: (args: string, ctx: ExtensionContext) => Promise<void> | void;
+    handler: (args: string, ctx: ExtensionCommandContext) => Promise<void> | void;
   }
 
   export interface ExtensionAPI {

--- a/types/pi-coding-agent.d.ts
+++ b/types/pi-coding-agent.d.ts
@@ -63,7 +63,6 @@ declare module "@earendil-works/pi-coding-agent" {
 
   export interface ExtensionContext {
     cwd: string;
-    mode?: "tui" | "rpc" | "json" | "print";
     hasUI?: boolean;
     isIdle?: () => boolean;
     ui: ExtensionUI;

--- a/types/pi-tui.d.ts
+++ b/types/pi-tui.d.ts
@@ -1,4 +1,20 @@
 declare module "@earendil-works/pi-tui" {
+  export interface Component {
+    render(width: number): string[];
+    handleInput?(data: string): void;
+    invalidate(): void;
+  }
+
+  export function matchesKey(data: string, key: string): boolean;
+  export function truncateToWidth(
+    text: string,
+    width: number,
+    ellipsis?: string,
+    pad?: boolean,
+  ): string;
+  export function visibleWidth(text: string): number;
+  export function wrapTextWithAnsi(text: string, width: number): string[];
+
   export class Text {
     constructor(text: string, x: number, y: number);
   }


### PR DESCRIPTION
Closes #993.

## Summary
- open a centered Pi-native goal overlay from `/goal` in interactive mode
- show objective, lifecycle status, budget bars, latest evaluator guidance, and continuation state
- preserve text output in print/JSON/RPC modes and add a useful no-goal state
- add focused rendering, width-safety, keyboard interaction, and command-mode tests
- declare the Pi TUI peer and extend local compatibility declarations

## Validation
- `pnpm prepush`
- `pnpm --filter @pinet/agent-goal build`
- `npm pack --dry-run` in `agent-goal/`
- `pnpm install --frozen-lockfile`
- isolated interactive Pi smoke test: `/goal` opened and `q` dismissed the overlay
- `git diff --check`