### PR TITLE
chore(release): prepare Pinet 0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ themselves create a new release entry, tag, or package version. Add a versioned
 entry only when a maintainer approves a real release with intentional package
 version bumps and publish scope.
 
+## [0.2.7] - 2026-08-22
+
+Pinet v0.2.7 adds a focused Pi-native goal window to the standalone single-agent goal loop while keeping the coordinated seven-package release set aligned.
+
+### Version verification
+
+- `pi-extensions` — `0.2.7` (private repo package)
+- `@pinet/transport-core` — `0.2.7`
+- `@pinet/broker-core` — `0.2.7`
+- `@pinet/pinet-core` — `0.2.7`
+- `@pinet/imessage-bridge` — `0.2.7`
+- `@pinet/slack-bridge` — `0.2.7`
+- `@pinet/model-aware-compaction` — `0.2.7`
+- `@pinet/agent-goal` — `0.2.7`
+
+### Release highlights
+
+- Opens a centered Pi-native goal window from `/goal` in interactive sessions without requiring tmux or a separate process.
+- Shows the objective, lifecycle state, iteration/token/runtime budgets, latest evaluator guidance, and continuation state in one focused view.
+- Supports Escape, Enter, `q`, and Ctrl+C dismissal while retaining the passive footer/widget status.
+- Preserves textual behavior in non-interactive contexts through Pi's real `ui.custom()` capability contract.
+- Enforces Pi's strict render-width contract, including bounded output for terminal widths below eight columns.
+
+### Notable pull requests
+
+- [#994](https://github.com/gugu91/pinet/pull/994) — add the minimal Pi-native goal window
+
+See the [full change set since v0.2.6](https://github.com/gugu91/pinet/compare/v0.2.6...v0.2.7).
+
 ## [0.2.6] - 2026-08-22
 
 Pinet v0.2.6 adds the standalone durable single-agent goal loop and tightens Slack bridge startup, mode boundaries, and dependency/release hygiene. It expands the coordinated npm release set to seven `@pinet/*` packages.

--- a/agent-goal/package.json
+++ b/agent-goal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/agent-goal",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "description": "Standalone single-agent durable goal loop for Pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/broker-core",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "description": "Transport-neutral broker kernel primitives for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/imessage-bridge",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "description": "macOS/iMessage send-first adapter and readiness helpers for pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/model-aware-compaction/package.json
+++ b/model-aware-compaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/model-aware-compaction",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "description": "Pi extension for proactive model-aware context compaction thresholds",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/pinet-core",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "description": "Pinet runtime core for pi — broker/follower orchestration and mesh tooling",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/slack-bridge",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "description": "Pi package for Pinet Slack assistant integration — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/transport-core",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "description": "Transport-neutral message contracts for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
Closes #995.

## Summary
- bump the private root and all seven public `@pinet/*` packages to `0.2.7`
- document the Pi-native `/goal` window shipped by #994
- preserve the coordinated dependency-order release process

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm prepush`
- `pnpm publish:npm` (all seven npm dry-runs)
- `git diff --check`