### PR TITLE
chore(release): prepare v0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ themselves create a new release entry, tag, or package version. Add a versioned
 entry only when a maintainer approves a real release with intentional package
 version bumps and publish scope.
 
+## [0.2.8] - 2026-08-23
+
+Pinet v0.2.8 makes independent validation automatic for every settled single-agent goal run while keeping the coordinated seven-package release set aligned.
+
+### Version verification
+
+- `pi-extensions` — `0.2.8` (private repo package)
+- `@pinet/transport-core` — `0.2.8`
+- `@pinet/broker-core` — `0.2.8`
+- `@pinet/pinet-core` — `0.2.8`
+- `@pinet/imessage-bridge` — `0.2.8`
+- `@pinet/slack-bridge` — `0.2.8`
+- `@pinet/model-aware-compaction` — `0.2.8`
+- `@pinet/agent-goal` — `0.2.8`
+
+### Release highlights
+
+- Invokes the independent evaluator exactly once for every settled active-goal run, even when the worker does not call `update_goal`.
+- Treats `update_goal` as an optional completion or blocker hint rather than a prerequisite for validation.
+- Evaluates goals created during the current run without charging work that may have happened before goal creation.
+- Preserves projected and concurrent settlement accounting through the durable compare-and-swap evaluation path.
+- Defers busy-session continuation attempts without consuming the bounded failure retry budget.
+- Retains the compatibility `goal.auto_continued` event for no-hint continuation decisions.
+
+### Notable pull requests
+
+- [#998](https://github.com/gugu91/pinet/pull/998) — validate every settled goal run automatically
+
+See the [full change set since v0.2.7](https://github.com/gugu91/pinet/compare/v0.2.7...v0.2.8).
+
 ## [0.2.7] - 2026-08-22
 
 Pinet v0.2.7 adds a focused Pi-native goal window to the standalone single-agent goal loop while keeping the coordinated seven-package release set aligned.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Pinet v0.2.8 makes independent validation automatic for every settled single-age
 
 - [#998](https://github.com/gugu91/pinet/pull/998) — validate every settled goal run automatically
 
-See the [full change set since v0.2.7](https://github.com/gugu91/pinet/compare/v0.2.7...v0.2.8).
+See the [full change set since the v0.2.7 release commit](https://github.com/gugu91/pinet/compare/a4f95bcdd32754fcef83cc13189d8ccadb8e93f6...v0.2.8).
 
 ## [0.2.7] - 2026-08-22
 

--- a/agent-goal/package.json
+++ b/agent-goal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/agent-goal",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "Standalone single-agent durable goal loop for Pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/broker-core",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "Transport-neutral broker kernel primitives for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/imessage-bridge",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "macOS/iMessage send-first adapter and readiness helpers for pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/model-aware-compaction/package.json
+++ b/model-aware-compaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/model-aware-compaction",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "Pi extension for proactive model-aware context compaction thresholds",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/pinet-core",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "Pinet runtime core for pi — broker/follower orchestration and mesh tooling",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/slack-bridge",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "Pi package for Pinet Slack assistant integration — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/transport-core",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "Transport-neutral message contracts for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
## Summary

- bump the private root and all seven coordinated public `@pinet/*` packages to `0.2.8`
- document automatic validation for every settled goal run
- retain compatibility and deterministic recovery notes

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm prepush`
- `pnpm publish:npm` (all seven packages, dry-run)
- `git diff --check`

Closes #999