### PR TITLE
fix(agent-goal): make goal window actionable

### DIFF
--- a/agent-goal/README.md
+++ b/agent-goal/README.md
@@ -25,11 +25,11 @@ pi -e ./agent-goal/index.ts
 /goal resume       Resume and immediately continue
 /goal complete     Mark complete manually
 /goal clear        Delete the goal
-/goal hide         Hide the persistent goal dashboard
-/goal show         Show the persistent goal dashboard
+/goal hide         Hide the compact persistent goal status
+/goal show         Show the compact persistent goal status
 ```
 
-Pi's footer shows the status and budget usage. A compact widget below the editor shows passive progress. In interactive mode, `/goal` opens a centered, keyboard-dismissable window with the objective, lifecycle state, budget bars, latest evaluator guidance, and continuation state. Press Escape, Enter, `q`, or Ctrl+C to close it. `/goal` remains a textual fallback in headless sessions.
+Pi's footer is the only persistent goal UI and shows compact status and budget usage without duplicating the detailed dashboard. In interactive mode, `/goal` opens the detailed control window with the objective, lifecycle state, budget bars, latest evaluator guidance, and continuation state. Its visible keyboard actions pause or resume the goal, mark it complete, clear it, or close the window; complete and clear require a second keypress, and the window refreshes after state changes. Press Escape, `q`, or Ctrl+C to close it. `/goal` retains the detailed textual dashboard in headless sessions.
 
 Only one goal may exist per Pi session. Clear the existing goal before creating another.
 

--- a/agent-goal/dashboard.test.ts
+++ b/agent-goal/dashboard.test.ts
@@ -21,7 +21,7 @@ const goal: AgentGoal = {
 };
 
 describe("goal dashboard", () => {
-  it("formats compact footer and widget state", () => {
+  it("formats compact footer and detailed headless state", () => {
     expect(formatGoalStatus(goal)).toBe("goal: active · 3/8 turns · 12430/50000 tok");
     expect(formatGoalDashboard(goal)).toEqual([
       "Goal · active · v4",

--- a/agent-goal/goal-window.test.ts
+++ b/agent-goal/goal-window.test.ts
@@ -44,7 +44,7 @@ const claim: GoalContinuationClaim = {
 
 describe("GoalWindow", () => {
   it("renders compact goal state and keeps every line within the available width", () => {
-    const window = new GoalWindow(goal, claim, theme, vi.fn(), () =>
+    const window = new GoalWindow(goal, claim, theme, vi.fn(), vi.fn(), () =>
       Date.parse("2026-01-01T00:15:00.000Z"),
     );
 
@@ -57,6 +57,7 @@ describe("GoalWindow", () => {
     expect(lines.join("\n")).toContain("15m/60m");
     expect(lines.join("\n")).toContain("Latest Interaction tests remain");
     expect(lines.join("\n")).toContain("Continuation deferred · attempt 2");
+    expect(lines.join("\n")).toContain("p pause · c complete · x clear · q close");
     expect(lines.every((line) => visibleWidth(line) <= 52)).toBe(true);
   });
 
@@ -77,21 +78,80 @@ describe("GoalWindow", () => {
     },
   );
 
-  it.each(["q", "Q", "\u001b", "\r", "\u0003"])("closes for %j", (input) => {
-    const onClose = vi.fn();
-    const window = new GoalWindow(goal, undefined, theme, onClose);
+  it.each(["q", "Q", "\u001b", "\u0003"])("closes for %j", (input) => {
+    const onAction = vi.fn();
+    const window = new GoalWindow(goal, undefined, theme, onAction);
 
     window.handleInput(input);
 
-    expect(onClose).toHaveBeenCalledOnce();
+    expect(onAction).toHaveBeenCalledWith("close");
   });
 
-  it("ignores unrelated input", () => {
-    const onClose = vi.fn();
-    const window = new GoalWindow(goal, undefined, theme, onClose);
+  it.each([
+    ["p", "pause"],
+    ["P", "pause"],
+  ] as const)("routes %s to %s", (input, action) => {
+    const onAction = vi.fn();
+    const window = new GoalWindow(goal, undefined, theme, onAction);
+
+    window.handleInput(input);
+
+    expect(onAction).toHaveBeenCalledWith(action);
+  });
+
+  it("offers resume for paused and blocked goals", () => {
+    const onPausedAction = vi.fn();
+    const onBlockedAction = vi.fn();
+    new GoalWindow({ ...goal, status: "paused" }, undefined, theme, onPausedAction).handleInput(
+      "r",
+    );
+    new GoalWindow({ ...goal, status: "blocked" }, undefined, theme, onBlockedAction).handleInput(
+      "r",
+    );
+
+    expect(onPausedAction).toHaveBeenCalledWith("resume");
+    expect(onBlockedAction).toHaveBeenCalledWith("resume");
+  });
+
+  it.each([
+    ["c", "complete"],
+    ["x", "clear"],
+  ] as const)("requires confirmation before %s", (input, action) => {
+    const onAction = vi.fn();
+    const requestRender = vi.fn();
+    const window = new GoalWindow(goal, undefined, theme, onAction, requestRender);
+
+    window.handleInput(input);
+
+    expect(onAction).not.toHaveBeenCalled();
+    expect(requestRender).toHaveBeenCalledOnce();
+    expect(window.render(52).join("\n")).toContain(`${input} again to confirm ${action}`);
+
+    window.handleInput(input);
+
+    expect(onAction).toHaveBeenCalledWith(action);
+  });
+
+  it("cancels a pending destructive action with escape", () => {
+    const onAction = vi.fn();
+    const requestRender = vi.fn();
+    const window = new GoalWindow(goal, undefined, theme, onAction, requestRender);
 
     window.handleInput("x");
+    window.handleInput("\u001b");
 
-    expect(onClose).not.toHaveBeenCalled();
+    expect(onAction).not.toHaveBeenCalled();
+    expect(requestRender).toHaveBeenCalledTimes(2);
+    expect(window.render(52).join("\n")).toContain("x clear");
+  });
+
+  it("ignores unavailable and unrelated actions", () => {
+    const onAction = vi.fn();
+    const window = new GoalWindow(goal, undefined, theme, onAction);
+
+    window.handleInput("r");
+    window.handleInput("z");
+
+    expect(onAction).not.toHaveBeenCalled();
   });
 });

--- a/agent-goal/goal-window.ts
+++ b/agent-goal/goal-window.ts
@@ -23,23 +23,60 @@ function compactNumber(value: number): string {
   return `${scaled.toFixed(scaled < 100 ? 1 : 0).replace(/\.0$/, "")}${suffix}`;
 }
 
+export type GoalWindowAction = "pause" | "resume" | "complete" | "clear" | "close";
+
+type ConfirmableGoalWindowAction = Extract<GoalWindowAction, "complete" | "clear">;
+
 export class GoalWindow implements Component {
+  private pendingConfirmation: ConfirmableGoalWindowAction | undefined;
+
   constructor(
     private readonly goal: AgentGoal | undefined,
     private readonly claim: GoalContinuationClaim | undefined,
     private readonly theme: Theme,
-    private readonly onClose: () => void,
+    private readonly onAction: (action: GoalWindowAction) => void,
+    private readonly requestRender: () => void = () => undefined,
     private readonly now: () => number = Date.now,
   ) {}
 
   handleInput(data: string): void {
-    if (
-      matchesKey(data, "escape") ||
-      matchesKey(data, "ctrl+c") ||
-      matchesKey(data, "return") ||
-      data.toLowerCase() === "q"
-    ) {
-      this.onClose();
+    const key = data.toLowerCase();
+    if (matchesKey(data, "ctrl+c") || key === "q") {
+      this.onAction("close");
+      return;
+    }
+    if (matchesKey(data, "escape")) {
+      if (this.pendingConfirmation) {
+        this.pendingConfirmation = undefined;
+        this.requestRender();
+      } else {
+        this.onAction("close");
+      }
+      return;
+    }
+    if (!this.goal) return;
+
+    if (this.pendingConfirmation) {
+      const confirmationKey = this.pendingConfirmation === "complete" ? "c" : "x";
+      if (key === confirmationKey) {
+        this.onAction(this.pendingConfirmation);
+      } else {
+        this.pendingConfirmation = undefined;
+        this.requestRender();
+      }
+      return;
+    }
+
+    if (key === "p" && this.goal.status === "active") {
+      this.onAction("pause");
+    } else if (key === "r" && (this.goal.status === "paused" || this.goal.status === "blocked")) {
+      this.onAction("resume");
+    } else if (key === "c" && this.goal.status !== "complete") {
+      this.pendingConfirmation = "complete";
+      this.requestRender();
+    } else if (key === "x") {
+      this.pendingConfirmation = "clear";
+      this.requestRender();
     }
   }
 
@@ -62,7 +99,7 @@ export class GoalWindow implements Component {
     if (!this.goal) {
       lines.push(row(), row(` ${this.theme.fg("muted", "No goal for this session.")}`));
       lines.push(row(` ${this.theme.fg("dim", "/goal <objective> to begin")}`), row());
-      lines.push(row(` ${this.theme.fg("dim", "esc · enter · q  close")}`));
+      lines.push(row(` ${this.theme.fg("dim", "esc · q  close")}`));
       lines.push(border(`╰${"─".repeat(innerWidth)}╯`));
       return lines;
     }
@@ -148,7 +185,17 @@ export class GoalWindow implements Component {
       );
     }
 
-    lines.push(row(), row(` ${this.theme.fg("dim", "esc · enter · q  close")}`));
+    const actions = [
+      this.goal.status === "active" ? "p pause" : undefined,
+      this.goal.status === "paused" || this.goal.status === "blocked" ? "r resume" : undefined,
+      this.goal.status !== "complete" ? "c complete" : undefined,
+      "x clear",
+      "q close",
+    ].filter((action): action is string => action !== undefined);
+    const footer = this.pendingConfirmation
+      ? `${this.pendingConfirmation === "complete" ? "c" : "x"} again to confirm ${this.pendingConfirmation} · esc cancel`
+      : actions.join(" · ");
+    lines.push(row(), row(` ${this.theme.fg("dim", footer)}`));
     lines.push(border(`╰${"─".repeat(innerWidth)}╯`));
     return lines;
   }

--- a/agent-goal/index.test.ts
+++ b/agent-goal/index.test.ts
@@ -8,7 +8,7 @@ import type {
 import type { Component } from "@earendil-works/pi-tui";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GoalProgressMessage } from "./progress.js";
-import { registerAgentGoal } from "./index.js";
+import { registerAgentGoal, type GoalWindowAction } from "./index.js";
 import { MemoryGoalStorage } from "./memory-storage.js";
 
 type GoalEventHandler = (
@@ -20,7 +20,7 @@ type GoalWindowFactory = (
   tui: { requestRender(): void },
   theme: Theme,
   keybindings: object,
-  done: (value: void) => void,
+  done: (value: GoalWindowAction) => void,
 ) => Component;
 
 afterEach(() => vi.useRealTimers());
@@ -218,6 +218,64 @@ describe("registerAgentGoal", () => {
       expect.objectContaining({ content: "This session has no goal." }),
       { triggerTurn: false },
     );
+  });
+
+  it("keeps passive UI compact and applies modal actions before refreshing", async () => {
+    const handlers = new Map<string, GoalEventHandler>();
+    const commands = new Map<string, RegisteredCommand>();
+    const pi = {
+      on(name: string, handler: GoalEventHandler) {
+        handlers.set(name, handler);
+      },
+      registerTool: vi.fn(),
+      registerCommand(name: string, command: RegisteredCommand) {
+        commands.set(name, command);
+      },
+      sendMessage: vi.fn(),
+    } as object as ExtensionAPI;
+    const storage = new MemoryGoalStorage();
+    await storage.create({
+      id: "goal-1",
+      scopeId: "session-1",
+      objective: "ship",
+      status: "active",
+      budget: { maxIterations: 5 },
+      usage: { iterations: 1, tokens: 10 },
+      version: 1,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const actions: GoalWindowAction[] = ["pause", "close"];
+    const custom = vi.fn(async (factory: GoalWindowFactory) => {
+      factory(
+        { requestRender: vi.fn() },
+        { fg: (_color, text) => text, bold: (text) => text } as Theme,
+        {},
+        vi.fn(),
+      );
+      return actions.shift();
+    });
+    const setStatus = vi.fn();
+    const setWidget = vi.fn();
+    const context = {
+      hasUI: true,
+      isIdle: () => true,
+      hasPendingMessages: () => false,
+      sessionManager: { getSessionId: () => "session-1" },
+      ui: { custom, setStatus, setWidget, notify: vi.fn() },
+    } as object as ExtensionCommandContext;
+    registerAgentGoal(pi, { storage });
+    const command = commands.get("goal");
+    if (!command) throw new Error("goal command was not registered");
+
+    await handlers.get("session_start")?.({}, context);
+    await command.handler("", context);
+
+    expect(setStatus).toHaveBeenCalledWith("agent-goal", "goal: active · 1/5 turns");
+    expect(setWidget).toHaveBeenCalledWith("agent-goal", undefined);
+    expect(custom).toHaveBeenCalledTimes(2);
+    expect(await storage.get("session-1")).toMatchObject({ status: "paused" });
+    expect(setStatus).toHaveBeenLastCalledWith("agent-goal", "goal: paused · 1/5 turns");
   });
 
   it.each(["complete", "blocked"] as const)(

--- a/agent-goal/index.ts
+++ b/agent-goal/index.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { formatGoalDashboard, formatGoalStatus } from "./dashboard.js";
-import { GoalWindow } from "./goal-window.js";
+import { GoalWindow, type GoalWindowAction } from "./goal-window.js";
 import type {
   GoalBudget,
   GoalContinuation,
@@ -44,7 +44,7 @@ export type {
   GoalWakeScheduler,
 } from "./domain.js";
 export { displayGoalText, formatGoalDashboard, formatGoalStatus } from "./dashboard.js";
-export { GoalWindow } from "./goal-window.js";
+export { GoalWindow, type GoalWindowAction } from "./goal-window.js";
 export { MemoryGoalStorage } from "./memory-storage.js";
 export { parseGoalEvaluation, PiGoalEvaluator } from "./pi-evaluator.js";
 export {
@@ -162,13 +162,30 @@ export function registerAgentGoal(pi: ExtensionAPI, options: AgentGoalExtensionO
   const refreshUi = async (ctx: CompatibleContext): Promise<void> => {
     const scopeId = ctx.sessionManager.getSessionId();
     const goal = await runtime.get(scopeId);
-    ctx.ui.setStatus(STATUS_KEY, goal ? formatGoalStatus(goal) : undefined);
-    if (!goal || hiddenScopes.has(scopeId)) {
-      ctx.ui.setWidget(WIDGET_KEY, undefined);
-      return;
+    const hidden = hiddenScopes.has(scopeId);
+    ctx.ui.setStatus(STATUS_KEY, goal && !hidden ? formatGoalStatus(goal) : undefined);
+    ctx.ui.setWidget(WIDGET_KEY, undefined);
+  };
+
+  const applyGoalAction = async (
+    scopeId: string,
+    action: Exclude<GoalWindowAction, "close">,
+  ): Promise<void> => {
+    switch (action) {
+      case "pause":
+        await runtime.setStatus(scopeId, "paused");
+        break;
+      case "resume":
+        await runtime.setStatus(scopeId, "active");
+        await runtime.start(scopeId, "Resume the goal from current state.");
+        break;
+      case "complete":
+        await runtime.setStatus(scopeId, "complete");
+        break;
+      case "clear":
+        if (!(await runtime.clear(scopeId))) throw new Error("This session has no goal");
+        break;
     }
-    const claim = await runtime.getContinuationClaim(scopeId);
-    ctx.ui.setWidget(WIDGET_KEY, formatGoalDashboard(goal, claim), { placement: "belowEditor" });
   };
 
   pi.on("session_start", async (_event, rawCtx) => {
@@ -397,53 +414,52 @@ export function registerAgentGoal(pi: ExtensionAPI, options: AgentGoalExtensionO
 
       try {
         if (!input) {
-          const goal = await runtime.get(scopeId);
-          const claim = await runtime.getContinuationClaim(scopeId);
           let openedWindow = false;
-          await ctx.ui.custom<void>(
-            (_tui, theme, _keybindings, done) => {
-              openedWindow = true;
-              return new GoalWindow(goal, claim, theme, () => done(undefined));
-            },
-            {
-              overlay: true,
-              overlayOptions: {
-                anchor: "center",
-                width: 66,
-                minWidth: 36,
-                maxHeight: "80%",
-                margin: 1,
+          while (true) {
+            const goal = await runtime.get(scopeId);
+            const claim = await runtime.getContinuationClaim(scopeId);
+            const action = await ctx.ui.custom<GoalWindowAction>(
+              (tui, theme, _keybindings, done) => {
+                openedWindow = true;
+                return new GoalWindow(goal, claim, theme, done, () => tui.requestRender());
               },
-            },
-          );
-          if (openedWindow) return;
-
-          api.sendMessage(
-            {
-              customType: "agent-goal.status",
-              content: goal
-                ? formatGoalDashboard(goal, claim).join("\n")
-                : "This session has no goal.",
-              display: true,
-            },
-            { triggerTurn: false },
-          );
-          return;
+              {
+                overlay: true,
+                overlayOptions: {
+                  anchor: "center",
+                  width: 66,
+                  minWidth: 36,
+                  maxHeight: "80%",
+                  margin: 1,
+                },
+              },
+            );
+            if (!openedWindow) {
+              api.sendMessage(
+                {
+                  customType: "agent-goal.status",
+                  content: goal
+                    ? formatGoalDashboard(goal, claim).join("\n")
+                    : "This session has no goal.",
+                  display: true,
+                },
+                { triggerTurn: false },
+              );
+              return;
+            }
+            if (!action || action === "close") return;
+            await applyGoalAction(scopeId, action);
+            await refreshUi(ctx);
+          }
         }
 
-        switch (input.toLowerCase()) {
+        const command = input.toLowerCase();
+        switch (command) {
           case "pause":
-            await runtime.setStatus(scopeId, "paused");
-            break;
           case "resume":
-            await runtime.setStatus(scopeId, "active");
-            await runtime.start(scopeId, "Resume the goal from current state.");
-            break;
           case "complete":
-            await runtime.setStatus(scopeId, "complete");
-            break;
           case "clear":
-            if (!(await runtime.clear(scopeId))) throw new Error("This session has no goal");
+            await applyGoalAction(scopeId, command);
             break;
           case "hide":
             hiddenScopes.add(scopeId);


### PR DESCRIPTION
## Summary

- make the interactive `/goal` modal route pause, resume, complete, and clear actions
- confirm complete/clear and refresh the modal after lifecycle changes
- remove the verbose persistent widget and retain only compact footer status
- preserve the detailed textual dashboard for headless contexts

## Validation

- `pnpm --filter @pinet/agent-goal test` (59 tests)
- `pnpm prepush`
- `git diff --check`
- isolated Pi TUI smoke: compact footer, pause/refresh, action discovery, clear confirmation, escape cancellation

Closes #1001