### PR TITLE
chore(release): prepare 0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ themselves create a new release entry, tag, or package version. Add a versioned
 entry only when a maintainer approves a real release with intentional package
 version bumps and publish scope.
 
+## [0.2.9] - 2026-08-23
+
+Pinet v0.2.9 turns the standalone single-agent goal window into an actionable control surface while reducing the persistent goal display to compact status.
+
+### Version verification
+
+- `pi-extensions` — `0.2.9` (private repo package)
+- `@pinet/transport-core` — `0.2.9`
+- `@pinet/broker-core` — `0.2.9`
+- `@pinet/pinet-core` — `0.2.9`
+- `@pinet/imessage-bridge` — `0.2.9`
+- `@pinet/slack-bridge` — `0.2.9`
+- `@pinet/model-aware-compaction` — `0.2.9`
+- `@pinet/agent-goal` — `0.2.9`
+
+### Release highlights
+
+- Adds keyboard-accessible pause, resume, complete, clear, and close actions to the interactive `/goal` modal.
+- Requires explicit confirmation before complete and clear actions.
+- Refreshes detailed goal information in the modal after lifecycle changes.
+- Removes the duplicated verbose persistent widget and retains compact footer status.
+- Preserves detailed textual `/goal` output for headless contexts and strict narrow-width rendering.
+
+### Notable pull requests
+
+- [#1002](https://github.com/gugu91/pinet/pull/1002) — make the goal window actionable and compact the passive UI
+
+See the [full change set since the v0.2.8 release commit](https://github.com/gugu91/pinet/compare/aff1cb6e6d10a2b3c96f1e24dd004e3196223f66...v0.2.9).
+
 ## [0.2.8] - 2026-08-23
 
 Pinet v0.2.8 makes independent validation automatic for every settled single-agent goal run while keeping the coordinated seven-package release set aligned.

--- a/agent-goal/package.json
+++ b/agent-goal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/agent-goal",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "description": "Standalone single-agent durable goal loop for Pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/broker-core",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "description": "Transport-neutral broker kernel primitives for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/imessage-bridge",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "description": "macOS/iMessage send-first adapter and readiness helpers for pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/model-aware-compaction/package.json
+++ b/model-aware-compaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/model-aware-compaction",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "description": "Pi extension for proactive model-aware context compaction thresholds",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/pinet-core",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "description": "Pinet runtime core for pi — broker/follower orchestration and mesh tooling",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/slack-bridge",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "description": "Pi package for Pinet Slack assistant integration — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/transport-core",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "description": "Transport-neutral message contracts for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
## Summary

- bump the private root and all seven public `@pinet/*` packages to `0.2.9`
- document the actionable `/goal` modal and compact passive status from #1002
- retain the coordinated dependency-ordered release set

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm prepush`
- `pnpm publish:npm` (dry-run for all seven packages)
- `npm pack --dry-run` for all seven packages
- `git diff --check`

Closes #1003