### PR TITLE
fix(model-aware-compaction): avoid native compaction race

### DIFF
--- a/model-aware-compaction/README.md
+++ b/model-aware-compaction/README.md
@@ -37,7 +37,7 @@ Rules are evaluated in order. `*` wildcards are supported, such as `example-prox
 
 ## Behavior
 
-After each `agent_end`, the extension reads `ctx.getContextUsage()` and the active `ctx.model`. Waiting for `agent_end` is important: tool-using runs can emit several `turn_end` events, and Pi's `ctx.compact()` aborts an active agent operation before compacting. Triggering only after the complete model/tool loop has settled prevents compaction from discarding pending tool work. When usage first exceeds the matching rule's `activeContextTokens`, the extension calls `ctx.compact()`. It prevents duplicate calls while compaction is in flight and re-arms after usage drops below the threshold, the model changes, a session starts, or compaction fails.
+After each `agent_settled`, the extension reads `ctx.getContextUsage()` and the active `ctx.model`. Pi can still auto-compact, retry, or process queued follow-ups after `agent_end`; waiting for `agent_settled` prevents proactive compaction from racing that automatic lifecycle. When usage first exceeds the matching rule's `activeContextTokens`, the extension calls `ctx.compact()`. It skips branches whose latest entry is already a compaction, prevents duplicate calls while compaction is in flight, and treats an `Already compacted` callback as an idempotent outcome. The threshold re-arms after usage drops below the limit, the model changes, a session starts, or another compaction failure occurs.
 
 Run `/model-aware-compaction-status` to inspect the active model, usage, matched threshold, state, and loaded rules.
 

--- a/model-aware-compaction/index.test.ts
+++ b/model-aware-compaction/index.test.ts
@@ -30,7 +30,12 @@ function context(tokens: number, compact = vi.fn()): ExtensionContext {
     cwd: process.cwd(),
     hasUI: false,
     ui: { notify: vi.fn(), setStatus: vi.fn() } as unknown as ExtensionContext["ui"],
-    sessionManager: {} as ExtensionContext["sessionManager"],
+    sessionManager: {
+      getEntries: () => [],
+      getBranch: () => [],
+      getLeafId: () => undefined,
+      getSessionFile: () => undefined,
+    },
     model: { provider: "openai", id: "gpt-5-mini" },
     getContextUsage: () => ({ tokens, contextWindow: 400_000, percent: tokens / 4_000 }),
     compact,
@@ -51,14 +56,14 @@ describe("extension wiring", () => {
       JSON.stringify({ "model-aware-compaction": { enabled: false } }),
     );
     try {
-      emit("agent_end", { ...context(120_000, compact), cwd: temp });
+      emit("agent_settled", { ...context(120_000, compact), cwd: temp });
       expect(compact).not.toHaveBeenCalled();
     } finally {
       fs.rmSync(temp, { recursive: true, force: true });
     }
   });
 
-  it("waits for the complete agent loop before compacting", () => {
+  it("waits for the full operation to settle before compacting", () => {
     const { emit } = harness();
     const compact = vi.fn();
     const temp = fs.mkdtempSync(path.join(os.tmpdir(), "model-aware-compaction-"));
@@ -70,12 +75,12 @@ describe("extension wiring", () => {
     try {
       const ctx = { ...context(120_000, compact), cwd: temp };
 
-      // Tool-using runs can emit several turn_end events before agent_end.
+      // Pi can still auto-compact and retry after agent_end.
       emit("turn_end", ctx);
-      emit("turn_end", ctx);
+      emit("agent_end", ctx);
       expect(compact).not.toHaveBeenCalled();
 
-      emit("agent_end", ctx);
+      emit("agent_settled", ctx);
       expect(compact).toHaveBeenCalledTimes(1);
     } finally {
       fs.rmSync(temp, { recursive: true, force: true });
@@ -96,22 +101,75 @@ describe("extension wiring", () => {
     );
     try {
       const ctx = { ...context(120_000, compact), cwd: temp };
-      emit("agent_end", ctx);
-      emit("agent_end", ctx);
+      emit("agent_settled", ctx);
+      emit("agent_settled", ctx);
       expect(compact).toHaveBeenCalledTimes(1);
 
       const options = compact.mock.calls[0]?.[0] as { onComplete?: () => void };
       options.onComplete?.();
-      emit("agent_end", ctx);
+      emit("agent_settled", ctx);
       expect(compact).toHaveBeenCalledTimes(1);
 
-      emit("agent_end", {
+      emit("agent_settled", {
         ...ctx,
         getContextUsage: () => ({ tokens: 90_000, contextWindow: 400_000, percent: 22.5 }),
       });
-      emit("agent_end", ctx);
+      emit("agent_settled", ctx);
       expect(compact).toHaveBeenCalledTimes(2);
     } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
+  it("skips a settled branch whose latest entry is already a compaction", () => {
+    const { emit } = harness();
+    const compact = vi.fn();
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), "model-aware-compaction-"));
+    fs.mkdirSync(path.join(temp, ".pi"));
+    fs.writeFileSync(
+      path.join(temp, ".pi", "settings.json"),
+      JSON.stringify({ "model-aware-compaction": { enabled: true } }),
+    );
+    try {
+      const base = context(120_000, compact);
+      const ctx = {
+        ...base,
+        cwd: temp,
+        sessionManager: {
+          ...base.sessionManager,
+          getBranch: () => [{ type: "compaction" }],
+        },
+      };
+      emit("agent_settled", ctx);
+      emit("agent_settled", ctx);
+      expect(compact).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
+  it("treats an already-compacted callback as an idempotent outcome", () => {
+    const { emit } = harness();
+    const compact = vi.fn();
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), "model-aware-compaction-"));
+    fs.mkdirSync(path.join(temp, ".pi"));
+    fs.writeFileSync(
+      path.join(temp, ".pi", "settings.json"),
+      JSON.stringify({ "model-aware-compaction": { enabled: true, debug: true } }),
+    );
+    try {
+      const ctx = { ...context(120_000, compact), cwd: temp, hasUI: true };
+      emit("agent_settled", ctx);
+      const options = compact.mock.calls[0]?.[0] as { onError?: (error: Error) => void };
+      options.onError?.(new Error("Already compacted"));
+      emit("agent_settled", ctx);
+
+      expect(compact).toHaveBeenCalledTimes(1);
+      expect(error).not.toHaveBeenCalledWith(expect.stringContaining("failed"));
+      expect(ctx.ui.notify).not.toHaveBeenCalledWith(expect.stringContaining("failed"), "error");
+    } finally {
+      error.mockRestore();
       fs.rmSync(temp, { recursive: true, force: true });
     }
   });
@@ -127,9 +185,9 @@ describe("extension wiring", () => {
     );
     try {
       const ctx = { ...context(120_000, compact), cwd: temp };
-      emit("agent_end", ctx);
+      emit("agent_settled", ctx);
       emit("model_select", ctx);
-      emit("agent_end", ctx);
+      emit("agent_settled", ctx);
       expect(compact).toHaveBeenCalledTimes(1);
     } finally {
       fs.rmSync(temp, { recursive: true, force: true });

--- a/model-aware-compaction/index.ts
+++ b/model-aware-compaction/index.ts
@@ -37,9 +37,9 @@ export default function modelAwareCompaction(pi: ExtensionAPI) {
   pi.on("session_start", rearm);
   pi.on("model_select", rearm);
 
-  // ctx.compact() aborts an active agent operation. Wait for the complete
-  // model/tool loop to settle so compaction cannot discard pending tool work.
-  pi.on("agent_end", (_event, rawCtx) => {
+  // agent_end may still be followed by Pi's automatic compaction and retry.
+  // Wait until the full operation settles so proactive compaction cannot race it.
+  pi.on("agent_settled", (_event, rawCtx) => {
     const ctx = rawCtx as CompatibleContext;
     const config = loadConfig(ctx.cwd);
     const usage = ctx.getContextUsage?.();
@@ -57,6 +57,11 @@ export default function modelAwareCompaction(pi: ExtensionAPI) {
     }
     if (!decision.shouldCompact || !ctx.compact || !decision.modelKey || decision.limit === null)
       return;
+
+    if (ctx.sessionManager.getBranch().at(-1)?.type === "compaction") {
+      triggeredModelKey = decision.modelKey;
+      return;
+    }
 
     inFlight = true;
     triggeredModelKey = decision.modelKey;
@@ -77,6 +82,8 @@ export default function modelAwareCompaction(pi: ExtensionAPI) {
       },
       onError: (error) => {
         inFlight = false;
+        if (error.message === "Already compacted") return;
+
         triggeredModelKey = null;
         console.error(`${LOG_PREFIX} failed ${details}: ${error.message}`);
         if (config.debug && ctx.hasUI)


### PR DESCRIPTION
## Summary

- trigger proactive model-aware compaction from `agent_settled` instead of `agent_end`
- skip branches already ending in a compaction before invoking Pi
- treat an `Already compacted` callback as an idempotent outcome without re-arming or duplicate extension errors
- document the corrected lifecycle and add regression coverage

## Root cause

Pi may still auto-compact and retry after `agent_end`. The extension requested a second manual compaction before that automatic lifecycle settled, so Pi rejected it as `Already compacted` and both Pi and the extension displayed errors.

## Validation

- 14 model-aware-compaction tests
- targeted lint and typecheck
- agent-standards lint
- full `pnpm prepush`
- `git diff --check`

Closes #1005