### PR TITLE
release: prepare coordinated 0.2.10 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ themselves create a new release entry, tag, or package version. Add a versioned
 entry only when a maintainer approves a real release with intentional package
 version bumps and publish scope.
 
+## [0.2.10] - 2026-08-23
+
+Pinet v0.2.10 prevents model-aware proactive compaction from racing Pi's native auto-compaction lifecycle.
+
+### Version verification
+
+- `pi-extensions` — `0.2.10` (private repo package)
+- `@pinet/transport-core` — `0.2.10`
+- `@pinet/broker-core` — `0.2.10`
+- `@pinet/pinet-core` — `0.2.10`
+- `@pinet/imessage-bridge` — `0.2.10`
+- `@pinet/slack-bridge` — `0.2.10`
+- `@pinet/model-aware-compaction` — `0.2.10`
+- `@pinet/agent-goal` — `0.2.10`
+
+### Release highlights
+
+- Moves proactive model-aware compaction from `agent_end` to the terminal `agent_settled` lifecycle event.
+- Skips compaction when the current session branch already ends in a compaction entry.
+- Treats Pi's `Already compacted` callback as an idempotent success instead of surfacing duplicate errors.
+- Adds regression coverage for native-compaction-first races, duplicate callbacks, in-flight guards, and trigger re-arming.
+
+### Notable pull requests
+
+- [#1006](https://github.com/gugu91/pinet/pull/1006) — avoid duplicate compaction after native auto-compaction
+
+See the [full change set since v0.2.9](https://github.com/gugu91/pinet/compare/v0.2.9...v0.2.10).
+
 ## [0.2.9] - 2026-08-23
 
 Pinet v0.2.9 turns the standalone single-agent goal window into an actionable control surface while reducing the persistent goal display to compact status.

--- a/agent-goal/package.json
+++ b/agent-goal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/agent-goal",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "module",
   "description": "Standalone single-agent durable goal loop for Pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/broker-core",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "module",
   "description": "Transport-neutral broker kernel primitives for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/imessage-bridge",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "module",
   "description": "macOS/iMessage send-first adapter and readiness helpers for pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/model-aware-compaction/package.json
+++ b/model-aware-compaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/model-aware-compaction",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "module",
   "description": "Pi extension for proactive model-aware context compaction thresholds",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/pinet-core",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "module",
   "description": "Pinet runtime core for pi — broker/follower orchestration and mesh tooling",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/slack-bridge",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "module",
   "description": "Pi package for Pinet Slack assistant integration — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/transport-core",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "module",
   "description": "Transport-neutral message contracts for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
## Summary

- bump the private root and all seven public `@pinet/*` packages to `0.2.10`
- add coordinated release notes for the model-aware compaction race fix
- retain dependency-ordered Trusted Publishing readiness

## Validation

- `pnpm prepush`
- coordinated publish dry-run for all seven public tarballs
- `git diff --check`

Closes #1007