### PR TITLE
feat(agent-goal): allow bounded budget updates

### DIFF
--- a/agent-goal/README.md
+++ b/agent-goal/README.md
@@ -21,6 +21,7 @@ pi -e ./agent-goal/index.ts
 ```text
 /goal <objective>  Create and immediately start a goal
 /goal              Open the minimal goal window (text in headless modes)
+/goal budget turns=<n> [tokens=<n>]  Change total turn/token ceilings
 /goal pause        Pause automatic evaluation and continuation
 /goal resume       Resume and immediately continue
 /goal complete     Mark complete manually
@@ -33,9 +34,10 @@ Pi's footer is the only persistent goal UI and shows compact status and budget u
 
 Only one goal may exist per Pi session. Clear the existing goal before creating another.
 
-The agent also receives three model-visible tools:
+The agent also receives four model-visible tools:
 
 - `create_goal` — create its own bounded, user-aligned durable goal
+- `update_goal_budget` — change the current goal's total turn or token ceiling
 - `get_goal` — inspect the current objective, status, and budget
 - `update_goal` — optionally attach a `complete` or `blocked` hint for independent verification
 
@@ -51,7 +53,9 @@ PI_AGENT_GOAL_MAX_TOKENS=200000
 PI_AGENT_GOAL_MAX_RUNTIME_MS=14400000
 ```
 
-Iteration and runtime limits are always reliable. Token accounting uses usage reported by Pi providers. The evaluator reviews every settled run, including the final allowed turn, so a completed goal is not incorrectly classified as budget-limited; only another continuation is prevented. The former `PI_AGENT_GOAL_EVALUATION_INTERVAL` setting is accepted for configuration compatibility but no longer changes evaluation frequency.
+Iteration and runtime limits are always reliable. Token accounting uses usage reported by Pi providers. Operators and the goal-bearing agent may update total turn and token ceilings without recreating the goal. Changes are optimistic and atomic, cannot reduce a ceiling below accounted usage, and cannot exceed a configured default ceiling when one exists. Increasing an exhausted budget reactivates the same goal when capacity is available; no budget change alters the objective or erases usage.
+
+The evaluator reviews every settled run, including the final allowed turn, so a completed goal is not incorrectly classified as budget-limited; only another continuation is prevented. The former `PI_AGENT_GOAL_EVALUATION_INTERVAL` setting is accepted for configuration compatibility but no longer changes evaluation frequency.
 
 ## Persistence and recovery
 
@@ -114,7 +118,7 @@ A future Pinet integration can use broker storage and evaluation plus RALPH reco
 
 ## Automatic evaluation
 
-The extension registers model-visible `create_goal`, `get_goal`, and `update_goal` tools. The worker can establish its own user-aligned goal and inspect it. `update_goal` is optional: it records a terminal hint rather than mutating goal state directly. Every `agent_settled` event accounts the run and invokes the independent evaluator whether or not the worker supplied that hint.
+The extension registers model-visible `create_goal`, `update_goal_budget`, `get_goal`, and `update_goal` tools. The worker can establish its own user-aligned goal, inspect it, and adjust its bounded capacity. `update_goal` is optional: it records a terminal hint rather than mutating goal state directly. Every `agent_settled` event accounts the run and invokes the independent evaluator whether or not the worker supplied that hint.
 
 The evaluator returns one of:
 

--- a/agent-goal/README.md
+++ b/agent-goal/README.md
@@ -53,7 +53,7 @@ PI_AGENT_GOAL_MAX_TOKENS=200000
 PI_AGENT_GOAL_MAX_RUNTIME_MS=14400000
 ```
 
-Iteration and runtime limits are always reliable. Token accounting uses usage reported by Pi providers. Operators and the goal-bearing agent may update total turn and token ceilings without recreating the goal. Changes are optimistic and atomic, cannot reduce a ceiling below accounted usage, and cannot exceed a configured default ceiling when one exists. Increasing an exhausted budget reactivates the same goal when capacity is available; no budget change alters the objective or erases usage.
+Iteration and runtime limits are always reliable. Token accounting uses usage reported by Pi providers. Operators and the goal-bearing agent may update total turn and token ceilings without recreating the goal. Changes are optimistic and atomic, cannot reduce a ceiling below accounted usage, must reserve capacity for a currently active turn, and cannot exceed a configured default ceiling when one exists. Increasing an exhausted budget reactivates the same goal when capacity is available; no budget change alters the objective or erases usage.
 
 The evaluator reviews every settled run, including the final allowed turn, so a completed goal is not incorrectly classified as budget-limited; only another continuation is prevented. The former `PI_AGENT_GOAL_EVALUATION_INTERVAL` setting is accepted for configuration compatibility but no longer changes evaluation frequency.
 

--- a/agent-goal/dashboard.test.ts
+++ b/agent-goal/dashboard.test.ts
@@ -28,7 +28,7 @@ describe("goal dashboard", () => {
       "Ship the standalone goal loop",
       "Turns 3/8 · Tokens 12430/50000 · Runtime limit 60m",
       "Last CONTINUE: tests remain",
-      "/goal pause · resume · complete · clear · hide",
+      "/goal budget turns=<n> tokens=<n> · pause · resume · complete · clear · hide",
     ]);
   });
 });

--- a/agent-goal/dashboard.ts
+++ b/agent-goal/dashboard.ts
@@ -41,6 +41,6 @@ export function formatGoalDashboard(goal: AgentGoal, claim?: GoalContinuationCla
   }
   if (goal.blockedReason) lines.push(`Reason: ${displayGoalText(goal.blockedReason, 100)}`);
   if (claim) lines.push(`Continuation: ${claim.state} · attempt ${claim.attempt}`);
-  lines.push("/goal pause · resume · complete · clear · hide");
+  lines.push("/goal budget turns=<n> tokens=<n> · pause · resume · complete · clear · hide");
   return lines;
 }

--- a/agent-goal/domain.ts
+++ b/agent-goal/domain.ts
@@ -11,6 +11,11 @@ export interface GoalUsage {
   tokens: number;
 }
 
+export interface GoalBudgetUpdate {
+  maxIterations?: number;
+  maxTokens?: number;
+}
+
 export interface GoalEvaluationRecord {
   id: string;
   outcome: GoalEvaluation["outcome"];
@@ -92,6 +97,7 @@ export interface GoalStorage {
   get(scopeId: string): Promise<AgentGoal | undefined>;
   create(goal: AgentGoal): Promise<void>;
   replace(goal: AgentGoal, expectedVersion: number): Promise<boolean>;
+  updateBudget(goal: AgentGoal, expectedVersion: number): Promise<boolean>;
   delete(scopeId: string, expectedVersion: number): Promise<boolean>;
   getPendingEvaluation(scopeId: string): Promise<GoalPendingEvaluation | undefined>;
   appendPendingEvaluation(pending: GoalPendingEvaluation): Promise<boolean>;
@@ -154,6 +160,7 @@ export type GoalEvent =
   | { type: "goal.created"; goal: AgentGoal }
   | { type: "goal.status_changed"; goal: AgentGoal; previousStatus: GoalStatus }
   | { type: "goal.progress_accounted"; goal: AgentGoal; tokenDelta: number }
+  | { type: "goal.budget_changed"; goal: AgentGoal; previousBudget: GoalBudget }
   | { type: "goal.evaluated"; goal: AgentGoal; evaluation: GoalEvaluation }
   | { type: "goal.auto_continued"; goal: AgentGoal }
   | {

--- a/agent-goal/index.test.ts
+++ b/agent-goal/index.test.ts
@@ -220,6 +220,62 @@ describe("registerAgentGoal", () => {
     );
   });
 
+  it("lets the operator and agent update the same bounded goal budget", async () => {
+    const tools = new Map<string, ToolDefinition>();
+    const commands = new Map<string, RegisteredCommand>();
+    const pi = {
+      on: vi.fn(),
+      registerTool(tool: ToolDefinition) {
+        tools.set(tool.name, tool);
+      },
+      registerCommand(name: string, command: RegisteredCommand) {
+        commands.set(name, command);
+      },
+      sendMessage: vi.fn(),
+    } as object as ExtensionAPI;
+    const storage = new MemoryGoalStorage();
+    await storage.create({
+      id: "goal-1",
+      scopeId: "session-1",
+      objective: "ship",
+      status: "active",
+      budget: { maxIterations: 5, maxTokens: 10_000 },
+      usage: { iterations: 1, tokens: 500 },
+      version: 1,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const notify = vi.fn();
+    const context = {
+      hasUI: true,
+      sessionManager: { getSessionId: () => "session-1" },
+      ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify },
+    } as object as ExtensionCommandContext;
+    registerAgentGoal(pi, {
+      storage,
+      defaultBudget: { maxIterations: 20, maxTokens: 100_000 },
+    });
+    const tool = tools.get("update_goal_budget");
+    const command = commands.get("goal");
+    if (!tool?.execute || !command) throw new Error("goal budget controls were not registered");
+
+    await tool.execute(
+      "call-1",
+      { maxTurns: 12, maxTokens: 50_000 },
+      new AbortController().signal,
+      undefined,
+      context,
+    );
+    await command.handler("budget turns=8 tokens=30000", context);
+
+    expect(await storage.get("session-1")).toMatchObject({
+      budget: { maxIterations: 8, maxTokens: 30_000 },
+      usage: { iterations: 1, tokens: 500 },
+      version: 3,
+    });
+    expect(notify).toHaveBeenCalledWith("Goal budget: 8 turns · 30000 tokens", "info");
+  });
+
   it("keeps passive UI compact and applies modal actions before refreshing", async () => {
     const handlers = new Map<string, GoalEventHandler>();
     const commands = new Map<string, RegisteredCommand>();

--- a/agent-goal/index.ts
+++ b/agent-goal/index.ts
@@ -326,6 +326,55 @@ export function registerAgentGoal(pi: ExtensionAPI, options: AgentGoalExtensionO
   });
 
   pi.registerTool({
+    name: "update_goal_budget",
+    label: "Update goal budget",
+    description:
+      "Adjust this session goal's bounded turn or token ceiling without replacing the goal. Changes remain constrained by configured limits and cannot discard accounted usage.",
+    promptSnippet: "Adjust the active session goal's bounded turn or token budget.",
+    promptGuidelines: [
+      "Only change a goal budget when more or less capacity is genuinely needed for the existing user-aligned objective.",
+      "Never use budget changes to broaden the objective or evade configured hard limits.",
+      "Inspect the current goal first and keep requested capacity proportionate to the remaining work.",
+    ],
+    parameters: {
+      type: "object",
+      properties: {
+        maxTurns: {
+          type: "integer",
+          minimum: 1,
+          maximum: defaultBudget.maxIterations,
+          description: "New total settled-turn ceiling, including turns already accounted.",
+        },
+        maxTokens: {
+          type: "number",
+          exclusiveMinimum: 0,
+          ...(defaultBudget.maxTokens === undefined ? {} : { maximum: defaultBudget.maxTokens }),
+          description: "New total token ceiling, including tokens already accounted.",
+        },
+      },
+      additionalProperties: false,
+    },
+    async execute(_toolCallId, rawParams, _signal, _onUpdate, rawCtx) {
+      const params = rawParams as { maxTurns?: number; maxTokens?: number };
+      const ctx = rawCtx as CompatibleContext;
+      const goal = await runtime.updateBudget(ctx.sessionManager.getSessionId(), {
+        maxIterations: params.maxTurns,
+        maxTokens: params.maxTokens,
+      });
+      await refreshUi(ctx);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Updated goal budget to ${goal.budget.maxIterations} turns${goal.budget.maxTokens === undefined ? "" : ` and ${goal.budget.maxTokens} tokens`}.`,
+          },
+        ],
+        details: { goal },
+      };
+    },
+  });
+
+  pi.registerTool({
     name: "get_goal",
     label: "Get goal",
     description: "Read the durable goal and budget state for this agent session.",
@@ -405,7 +454,7 @@ export function registerAgentGoal(pi: ExtensionAPI, options: AgentGoalExtensionO
 
   pi.registerCommand("goal", {
     description:
-      "Create, inspect, pause, resume, complete, clear, show, or hide this session's goal",
+      "Create, inspect, adjust budget, pause, resume, complete, clear, show, or hide this session's goal",
     handler: async (args, rawCtx) => {
       const ctx = rawCtx as CompatibleContext;
       activeContext = ctx;
@@ -454,6 +503,31 @@ export function registerAgentGoal(pi: ExtensionAPI, options: AgentGoalExtensionO
         }
 
         const command = input.toLowerCase();
+        if (command === "budget" || command.startsWith("budget ")) {
+          const update: { maxIterations?: number; maxTokens?: number } = {};
+          for (const token of input.slice("budget".length).trim().split(/\s+/).filter(Boolean)) {
+            const separator = token.indexOf("=");
+            if (separator < 1) throw new Error(`Invalid goal budget argument: ${token}`);
+            const key = token.slice(0, separator).toLowerCase();
+            const value = Number(token.slice(separator + 1));
+            if (key === "turns" || key === "maxturns" || key === "iterations") {
+              update.maxIterations = value;
+            } else if (key === "tokens" || key === "maxtokens") {
+              update.maxTokens = value;
+            } else {
+              throw new Error(`Unknown goal budget field: ${key}`);
+            }
+          }
+          const goal = await runtime.updateBudget(scopeId, update);
+          await refreshUi(ctx);
+          if (ctx.hasUI) {
+            ctx.ui.notify(
+              `Goal budget: ${goal.budget.maxIterations} turns${goal.budget.maxTokens === undefined ? "" : ` · ${goal.budget.maxTokens} tokens`}`,
+              "info",
+            );
+          }
+          return;
+        }
         switch (command) {
           case "pause":
           case "resume":

--- a/agent-goal/memory-storage.ts
+++ b/agent-goal/memory-storage.ts
@@ -38,6 +38,25 @@ export class MemoryGoalStorage implements GoalStorage {
     return true;
   }
 
+  async updateBudget(goal: AgentGoal, expectedVersion: number): Promise<boolean> {
+    const current = this.goals.get(goal.scopeId);
+    if (!current || current.version !== expectedVersion || current.id !== goal.id) return false;
+    this.goals.set(goal.scopeId, cloneGoal(goal));
+    const pending = this.pendingEvaluations.get(goal.scopeId);
+    if (pending?.goalId === goal.id && pending.goalVersion === expectedVersion) {
+      this.pendingEvaluations.set(goal.scopeId, { ...pending, goalVersion: goal.version });
+    }
+    const candidate = this.terminalCandidates.get(goal.scopeId);
+    if (candidate?.goalId === goal.id && candidate.goalVersion === expectedVersion) {
+      this.terminalCandidates.set(goal.scopeId, { ...candidate, goalVersion: goal.version });
+    }
+    const claim = this.claims.get(goal.scopeId);
+    if (claim?.goalId === goal.id && claim.goalVersion === expectedVersion) {
+      this.claims.set(goal.scopeId, { ...claim, goalVersion: goal.version });
+    }
+    return true;
+  }
+
   async delete(scopeId: string, expectedVersion: number): Promise<boolean> {
     const current = this.goals.get(scopeId);
     if (!current || current.version !== expectedVersion) return false;

--- a/agent-goal/memory-storage.ts
+++ b/agent-goal/memory-storage.ts
@@ -83,14 +83,13 @@ export class MemoryGoalStorage implements GoalStorage {
 
   async appendPendingEvaluation(pending: GoalPendingEvaluation): Promise<boolean> {
     const goal = this.goals.get(pending.scopeId);
-    if (!goal || goal.id !== pending.goalId || goal.version !== pending.goalVersion) return false;
+    if (!goal || goal.id !== pending.goalId || goal.status !== "active") return false;
     const stored = this.pendingEvaluations.get(pending.scopeId);
     const existing =
-      stored?.goalId === pending.goalId && stored.goalVersion === pending.goalVersion
-        ? stored
-        : undefined;
+      stored?.goalId === pending.goalId && stored.goalVersion === goal.version ? stored : undefined;
     this.pendingEvaluations.set(pending.scopeId, {
       ...pending,
+      goalVersion: goal.version,
       iterationsDelta: pending.iterationsDelta + (existing?.iterationsDelta ?? 0),
       progress: {
         ...pending.progress,
@@ -203,8 +202,18 @@ export class MemoryGoalStorage implements GoalStorage {
     expectedClaimId: string,
   ): Promise<boolean> {
     const current = this.claims.get(claim.scopeId);
-    if (!current || current.claimId !== expectedClaimId) return false;
-    this.claims.set(claim.scopeId, { ...claim });
+    const goal = this.goals.get(claim.scopeId);
+    if (
+      !current ||
+      current.claimId !== expectedClaimId ||
+      current.goalId !== claim.goalId ||
+      !goal ||
+      goal.id !== claim.goalId ||
+      goal.status !== "active"
+    ) {
+      return false;
+    }
+    this.claims.set(claim.scopeId, { ...claim, goalVersion: goal.version });
     return true;
   }
 

--- a/agent-goal/runtime.test.ts
+++ b/agent-goal/runtime.test.ts
@@ -48,6 +48,149 @@ describe("GoalRuntime", () => {
     ).rejects.toThrow("maxRuntimeMs");
   });
 
+  it("updates turn and token budgets atomically within configured ceilings", async () => {
+    const events: GoalEvent[] = [];
+    const runtime = new GoalRuntime(
+      new MemoryGoalStorage(),
+      { evaluate: vi.fn() },
+      startedContinuation(),
+      () => new Date("2026-01-01T00:00:00.000Z"),
+      {
+        defaultBudget: { maxIterations: 20, maxTokens: 100_000 },
+        eventSink: { record: (event) => void events.push(event) },
+      },
+    );
+    await runtime.create("session-1", "ship", { maxIterations: 5, maxTokens: 10_000 });
+
+    const increased = await runtime.updateBudget("session-1", {
+      maxIterations: 12,
+      maxTokens: 50_000,
+    });
+    const decreased = await runtime.updateBudget("session-1", {
+      maxIterations: 8,
+      maxTokens: 30_000,
+    });
+
+    expect(increased).toMatchObject({
+      budget: { maxIterations: 12, maxTokens: 50_000 },
+      version: 2,
+    });
+    expect(decreased).toMatchObject({
+      budget: { maxIterations: 8, maxTokens: 30_000 },
+      version: 3,
+    });
+    expect(events.filter(({ type }) => type === "goal.budget_changed")).toHaveLength(2);
+    expect(events.at(-1)).toMatchObject({
+      type: "goal.budget_changed",
+      previousBudget: { maxIterations: 12, maxTokens: 50_000 },
+    });
+  });
+
+  it("enforces configured ceilings, accounted usage, and optimistic versions", async () => {
+    const storage = new MemoryGoalStorage();
+    const runtime = new GoalRuntime(
+      storage,
+      { evaluate: vi.fn().mockResolvedValue({ outcome: "continue", reason: "more work" }) },
+      startedContinuation(),
+      undefined,
+      { defaultBudget: { maxIterations: 10, maxTokens: 1_000 } },
+    );
+    await runtime.create("session-1", "ship");
+    await runtime.settle("session-1", { latestOutput: "work", tokenDelta: 100 });
+
+    await expect(runtime.updateBudget("session-1", { maxIterations: 11 })).rejects.toThrow(
+      "configured limit",
+    );
+    await expect(runtime.updateBudget("session-1", { maxTokens: 1_001 })).rejects.toThrow(
+      "configured limit",
+    );
+    await expect(runtime.updateBudget("session-1", { maxIterations: 0 })).rejects.toThrow(
+      "positive integer",
+    );
+    await expect(runtime.updateBudget("session-1", { maxIterations: 0.5 })).rejects.toThrow(
+      "positive integer",
+    );
+    await expect(runtime.updateBudget("session-1", { maxTokens: 99 })).rejects.toThrow(
+      "accounted tokens",
+    );
+    await expect(runtime.updateBudget("session-1", {})).rejects.toThrow("requires");
+
+    vi.spyOn(storage, "updateBudget").mockResolvedValueOnce(false);
+    await expect(runtime.updateBudget("session-1", { maxIterations: 9 })).rejects.toThrow(
+      "changed while its budget",
+    );
+  });
+
+  it("reactivates an exhausted goal when a larger budget restores capacity", async () => {
+    const continuation = startedContinuation();
+    const runtime = new GoalRuntime(
+      new MemoryGoalStorage(),
+      { evaluate: vi.fn().mockResolvedValue({ outcome: "continue", reason: "more work" }) },
+      continuation,
+      undefined,
+      { defaultBudget: { maxIterations: 5, maxTokens: 10_000 } },
+    );
+    await runtime.create("session-1", "ship", { maxIterations: 1, maxTokens: 100 });
+    await runtime.settle("session-1", { latestOutput: "first pass", tokenDelta: 100 });
+    expect(await runtime.get("session-1")).toMatchObject({ status: "budget_limited" });
+
+    const updated = await runtime.updateBudget("session-1", {
+      maxIterations: 2,
+      maxTokens: 200,
+    });
+
+    expect(updated).toMatchObject({
+      status: "active",
+      budget: { maxIterations: 2, maxTokens: 200 },
+      usage: { iterations: 1, tokens: 100 },
+      blockedReason: undefined,
+    });
+    expect(continuation.continueIfIdle).toHaveBeenCalledOnce();
+  });
+
+  it("preserves in-flight settlement accounting across a concurrent budget update", async () => {
+    let evaluationStarted: (() => void) | undefined;
+    let resolveEvaluation: ((value: { outcome: "continue"; reason: string }) => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      evaluationStarted = resolve;
+    });
+    const evaluator: GoalEvaluator = {
+      evaluate: vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveEvaluation = resolve;
+              evaluationStarted?.();
+            }),
+        )
+        .mockResolvedValue({ outcome: "continue", reason: "current budget evaluated" }),
+    };
+    const runtime = new GoalRuntime(
+      new MemoryGoalStorage(),
+      evaluator,
+      startedContinuation(),
+      undefined,
+      { defaultBudget: { maxIterations: 10, maxTokens: 10_000 } },
+    );
+    await runtime.create("session-1", "ship", { maxIterations: 5, maxTokens: 1_000 });
+
+    const settlement = runtime.settle("session-1", {
+      latestOutput: "concurrent work",
+      tokenDelta: 250,
+    });
+    await started;
+    await runtime.updateBudget("session-1", { maxIterations: 8, maxTokens: 2_000 });
+    resolveEvaluation?.({ outcome: "continue", reason: "stale budget evaluated" });
+    await settlement;
+
+    expect(await runtime.get("session-1")).toMatchObject({
+      budget: { maxIterations: 8, maxTokens: 2_000 },
+      usage: { iterations: 1, tokens: 250 },
+    });
+    expect(evaluator.evaluate).toHaveBeenCalledTimes(2);
+  });
+
   it("evaluates ordinary settled progress and continues when work remains", async () => {
     const continuation = startedContinuation();
     const evaluator = {

--- a/agent-goal/runtime.test.ts
+++ b/agent-goal/runtime.test.ts
@@ -110,10 +110,22 @@ describe("GoalRuntime", () => {
     await expect(runtime.updateBudget("session-1", { maxIterations: 0.5 })).rejects.toThrow(
       "positive integer",
     );
+    await expect(runtime.updateBudget("session-1", { maxIterations: 1 })).rejects.toThrow(
+      "current turn",
+    );
+    await expect(runtime.updateBudget("session-1", { maxTokens: 100 })).rejects.toThrow(
+      "capacity beyond",
+    );
     await expect(runtime.updateBudget("session-1", { maxTokens: 99 })).rejects.toThrow(
-      "accounted tokens",
+      "capacity beyond",
     );
     await expect(runtime.updateBudget("session-1", {})).rejects.toThrow("requires");
+
+    await runtime.settle("session-1", { latestOutput: "next work", tokenDelta: 200 });
+    expect(await runtime.get("session-1")).toMatchObject({
+      status: "active",
+      usage: { iterations: 2, tokens: 300 },
+    });
 
     vi.spyOn(storage, "updateBudget").mockResolvedValueOnce(false);
     await expect(runtime.updateBudget("session-1", { maxIterations: 9 })).rejects.toThrow(

--- a/agent-goal/runtime.test.ts
+++ b/agent-goal/runtime.test.ts
@@ -148,6 +148,48 @@ describe("GoalRuntime", () => {
     expect(continuation.continueIfIdle).toHaveBeenCalledOnce();
   });
 
+  it("binds a settlement to the latest budget version when the update wins first", async () => {
+    const storage = new MemoryGoalStorage();
+    const append = storage.appendPendingEvaluation.bind(storage);
+    let appendStarted: (() => void) | undefined;
+    let releaseAppend: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      appendStarted = resolve;
+    });
+    const release = new Promise<void>((resolve) => {
+      releaseAppend = resolve;
+    });
+    vi.spyOn(storage, "appendPendingEvaluation").mockImplementationOnce(async (pending) => {
+      appendStarted?.();
+      await release;
+      return append(pending);
+    });
+    const runtime = new GoalRuntime(
+      storage,
+      { evaluate: vi.fn().mockResolvedValue({ outcome: "complete", reason: "verified" }) },
+      startedContinuation(),
+      undefined,
+      { defaultBudget: { maxIterations: 10, maxTokens: 10_000 } },
+    );
+    await runtime.create("session-1", "ship", { maxIterations: 5, maxTokens: 1_000 });
+
+    const settlement = runtime.settle("session-1", {
+      latestOutput: "settled work",
+      tokenDelta: 250,
+      terminalCandidate: { outcome: "complete", reason: "checks passed" },
+    });
+    await started;
+    await runtime.updateBudget("session-1", { maxIterations: 8, maxTokens: 2_000 });
+    releaseAppend?.();
+    await settlement;
+
+    expect(await runtime.get("session-1")).toMatchObject({
+      status: "complete",
+      budget: { maxIterations: 8, maxTokens: 2_000 },
+      usage: { iterations: 1, tokens: 250 },
+    });
+  });
+
   it("preserves in-flight settlement accounting across a concurrent budget update", async () => {
     let evaluationStarted: (() => void) | undefined;
     let resolveEvaluation: ((value: { outcome: "continue"; reason: string }) => void) | undefined;
@@ -189,6 +231,56 @@ describe("GoalRuntime", () => {
       usage: { iterations: 1, tokens: 250 },
     });
     expect(evaluator.evaluate).toHaveBeenCalledTimes(2);
+  });
+
+  it("rebinds an in-flight continuation retry after a concurrent budget update", async () => {
+    let continuationStarted: (() => void) | undefined;
+    let resolveContinuation:
+      | ((value: { status: "unavailable"; reason: string; retryAfterMs: number }) => void)
+      | undefined;
+    const started = new Promise<void>((resolve) => {
+      continuationStarted = resolve;
+    });
+    const continuation: GoalContinuation = {
+      continueIfIdle: vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveContinuation = resolve;
+              continuationStarted?.();
+            }),
+        )
+        .mockResolvedValue({ status: "started" }),
+    };
+    const runtime = new GoalRuntime(
+      new MemoryGoalStorage(),
+      { evaluate: vi.fn().mockResolvedValue({ outcome: "continue", reason: "more work" }) },
+      continuation,
+      undefined,
+      {
+        defaultBudget: { maxIterations: 10, maxTokens: 10_000 },
+        retryPolicy: { maxAttempts: 3, baseDelayMs: 1, maxDelayMs: 1 },
+      },
+    );
+    await runtime.create("session-1", "ship", { maxIterations: 5, maxTokens: 1_000 });
+
+    const settlement = runtime.settle("session-1", {
+      latestOutput: "first pass",
+      tokenDelta: 100,
+    });
+    await started;
+    await runtime.updateBudget("session-1", { maxIterations: 8, maxTokens: 2_000 });
+    resolveContinuation?.({ status: "unavailable", reason: "offline", retryAfterMs: 0 });
+    await settlement;
+
+    const goal = await runtime.get("session-1");
+    expect(goal).toMatchObject({ status: "active", version: 3 });
+    expect(await runtime.getContinuationClaim("session-1")).toMatchObject({
+      goalVersion: goal?.version,
+      state: "started",
+    });
+    expect(continuation.continueIfIdle).toHaveBeenCalledTimes(2);
   });
 
   it("evaluates ordinary settled progress and continues when work remains", async () => {

--- a/agent-goal/runtime.ts
+++ b/agent-goal/runtime.ts
@@ -579,6 +579,24 @@ export class GoalRuntime {
       const currentGoal = await this.storage.get(goal.scopeId);
       const currentClaim = await this.storage.getContinuationClaim(goal.scopeId);
       if (
+        currentGoal?.id === goal.id &&
+        currentGoal.status === "active" &&
+        currentGoal.version !== goal.version &&
+        currentClaim?.claimId === claim.claimId
+      ) {
+        if (currentClaim.state === "started") {
+          this.scheduleRecovery(goal.scopeId, currentClaim.expiresAt);
+        } else if (
+          currentClaim.state === "deferred" &&
+          Date.parse(currentClaim.availableAt) > this.now().getTime()
+        ) {
+          this.scheduleRecovery(goal.scopeId, currentClaim.availableAt);
+        } else {
+          await this.runContinuationClaim(currentGoal, currentClaim);
+        }
+        return;
+      }
+      if (
         !currentGoal ||
         currentGoal.id !== goal.id ||
         currentGoal.version !== goal.version ||

--- a/agent-goal/runtime.ts
+++ b/agent-goal/runtime.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type {
   AgentGoal,
   GoalBudget,
+  GoalBudgetUpdate,
   GoalContinuation,
   GoalContinuationClaim,
   GoalEvaluation,
@@ -127,6 +128,81 @@ export class GoalRuntime {
     await this.storage.create(goal);
     await this.record({ type: "goal.created", goal });
     return goal;
+  }
+
+  async updateBudget(scopeId: string, update: GoalBudgetUpdate): Promise<AgentGoal> {
+    const current = await this.requireGoal(scopeId);
+    if (current.status === "complete") throw new Error("Cannot change a complete goal budget");
+    if (update.maxIterations === undefined && update.maxTokens === undefined) {
+      throw new Error("A goal budget update requires maxIterations or maxTokens");
+    }
+    if (
+      update.maxIterations !== undefined &&
+      (!Number.isInteger(update.maxIterations) || update.maxIterations <= 0)
+    ) {
+      throw new Error("Goal maxIterations must be a positive integer");
+    }
+    if (
+      update.maxTokens !== undefined &&
+      (!Number.isFinite(update.maxTokens) || update.maxTokens <= 0)
+    ) {
+      throw new Error("Goal maxTokens must be a positive finite number");
+    }
+    if (update.maxIterations !== undefined && update.maxIterations > this.budget.maxIterations) {
+      throw new Error(
+        `Goal maxIterations cannot exceed the configured limit of ${this.budget.maxIterations}`,
+      );
+    }
+    if (
+      update.maxTokens !== undefined &&
+      this.budget.maxTokens !== undefined &&
+      update.maxTokens > this.budget.maxTokens
+    ) {
+      throw new Error(
+        `Goal maxTokens cannot exceed the configured limit of ${this.budget.maxTokens}`,
+      );
+    }
+    if (update.maxIterations !== undefined && update.maxIterations < current.usage.iterations) {
+      throw new Error(
+        `Goal maxIterations cannot be lower than ${current.usage.iterations} accounted turns`,
+      );
+    }
+    if (update.maxTokens !== undefined && update.maxTokens < current.usage.tokens) {
+      throw new Error(
+        `Goal maxTokens cannot be lower than ${current.usage.tokens} accounted tokens`,
+      );
+    }
+
+    const nextBudget: GoalBudget = {
+      ...current.budget,
+      ...(update.maxIterations === undefined ? {} : { maxIterations: update.maxIterations }),
+      ...(update.maxTokens === undefined ? {} : { maxTokens: update.maxTokens }),
+    };
+    const candidate: AgentGoal = {
+      ...current,
+      budget: nextBudget,
+      version: current.version + 1,
+      updatedAt: this.now().toISOString(),
+    };
+    const exhausted = this.budgetExhausted(candidate);
+    const next =
+      current.status === "budget_limited" && !exhausted
+        ? { ...candidate, status: "active" as const, blockedReason: undefined }
+        : current.status === "active" && exhausted
+          ? {
+              ...candidate,
+              status: "budget_limited" as const,
+              blockedReason: "Goal continuation budget exhausted",
+            }
+          : candidate;
+    if (!(await this.storage.updateBudget(next, current.version))) {
+      throw new Error("Goal changed while its budget was being updated; retry the command");
+    }
+    await this.record({ type: "goal.budget_changed", goal: next, previousBudget: current.budget });
+    if (current.status === "budget_limited" && next.status === "active") {
+      await this.continueWithClaim(next, "Continue with the expanded goal budget.");
+    }
+    return next;
   }
 
   async setStatus(

--- a/agent-goal/runtime.ts
+++ b/agent-goal/runtime.ts
@@ -162,14 +162,22 @@ export class GoalRuntime {
         `Goal maxTokens cannot exceed the configured limit of ${this.budget.maxTokens}`,
       );
     }
-    if (update.maxIterations !== undefined && update.maxIterations < current.usage.iterations) {
+    const minimumIterations =
+      current.status === "active" ? current.usage.iterations + 1 : current.usage.iterations;
+    if (update.maxIterations !== undefined && update.maxIterations < minimumIterations) {
       throw new Error(
-        `Goal maxIterations cannot be lower than ${current.usage.iterations} accounted turns`,
+        current.status === "active"
+          ? `Goal maxIterations must leave capacity for the current turn (${minimumIterations} minimum)`
+          : `Goal maxIterations cannot be lower than ${current.usage.iterations} accounted turns`,
       );
     }
-    if (update.maxTokens !== undefined && update.maxTokens < current.usage.tokens) {
+    const minimumTokens =
+      current.status === "active" ? current.usage.tokens + 1 : current.usage.tokens;
+    if (update.maxTokens !== undefined && update.maxTokens < minimumTokens) {
       throw new Error(
-        `Goal maxTokens cannot be lower than ${current.usage.tokens} accounted tokens`,
+        current.status === "active"
+          ? `Goal maxTokens must leave capacity beyond ${current.usage.tokens} accounted tokens`
+          : `Goal maxTokens cannot be lower than ${current.usage.tokens} accounted tokens`,
       );
     }
 
@@ -188,13 +196,7 @@ export class GoalRuntime {
     const next =
       current.status === "budget_limited" && !exhausted
         ? { ...candidate, status: "active" as const, blockedReason: undefined }
-        : current.status === "active" && exhausted
-          ? {
-              ...candidate,
-              status: "budget_limited" as const,
-              blockedReason: "Goal continuation budget exhausted",
-            }
-          : candidate;
+        : candidate;
     if (!(await this.storage.updateBudget(next, current.version))) {
       throw new Error("Goal changed while its budget was being updated; retry the command");
     }

--- a/agent-goal/sqlite-storage.test.ts
+++ b/agent-goal/sqlite-storage.test.ts
@@ -108,6 +108,31 @@ describe("SqliteGoalStorage", () => {
     second.close();
   });
 
+  it("updates a budget and dependent goal versions in one transaction", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "agent-goal-budget-"));
+    tempDirectories.push(directory);
+    const storage = new SqliteGoalStorage(join(directory, "goals.sqlite"));
+    await storage.create(goal);
+    expect(await storage.putPendingEvaluation(pending)).toBe(true);
+    expect(await storage.putTerminalCandidate(candidate)).toBe(true);
+    expect(await storage.createContinuationClaim(claim)).toBe(true);
+
+    const updated = {
+      ...goal,
+      budget: { maxIterations: 20, maxTokens: 75_000 },
+      version: 4,
+      updatedAt: "2026-01-01T00:02:00.000Z",
+    };
+    expect(await storage.updateBudget(updated, 3)).toBe(true);
+
+    expect(await storage.get("session-1")).toEqual(updated);
+    expect(await storage.getPendingEvaluation("session-1")).toMatchObject({ goalVersion: 4 });
+    expect(await storage.getTerminalCandidate("session-1")).toMatchObject({ goalVersion: 4 });
+    expect(await storage.getContinuationClaim("session-1")).toMatchObject({ goalVersion: 4 });
+    expect(await storage.updateBudget({ ...updated, version: 5 }, 3)).toBe(false);
+    storage.close();
+  });
+
   it("atomically aggregates superseding pending settlements", async () => {
     const directory = mkdtempSync(join(tmpdir(), "agent-goal-"));
     tempDirectories.push(directory);

--- a/agent-goal/sqlite-storage.test.ts
+++ b/agent-goal/sqlite-storage.test.ts
@@ -2,13 +2,14 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentGoal,
   GoalContinuationClaim,
   GoalPendingEvaluation,
   GoalTerminalCandidateRecord,
 } from "./domain.js";
+import { GoalRuntime } from "./runtime.js";
 import { SqliteGoalStorage } from "./sqlite-storage.js";
 
 const tempDirectories: string[] = [];
@@ -151,6 +152,34 @@ describe("SqliteGoalStorage", () => {
     });
     expect(await storage.updateBudget({ ...updated, version: 5 }, 3)).toBe(false);
     storage.close();
+  });
+
+  it("does not let a live goal lower its budget onto already-accounted usage", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "agent-goal-live-budget-"));
+    tempDirectories.push(directory);
+    const storage = new SqliteGoalStorage(join(directory, "goals.sqlite"));
+    await storage.create(goal);
+    const runtime = new GoalRuntime(
+      storage,
+      { evaluate: vi.fn().mockResolvedValue({ outcome: "complete", reason: "verified" }) },
+      { continueIfIdle: vi.fn().mockResolvedValue({ status: "started" }) },
+      undefined,
+      { defaultBudget: { maxIterations: 25, maxTokens: 100_000 } },
+    );
+
+    await expect(runtime.updateBudget("session-1", { maxIterations: 2 })).rejects.toThrow(
+      "current turn",
+    );
+    await expect(runtime.updateBudget("session-1", { maxTokens: 1_200 })).rejects.toThrow(
+      "capacity beyond",
+    );
+    await runtime.settle("session-1", { latestOutput: "in-flight work", tokenDelta: 100 });
+
+    expect(await runtime.get("session-1")).toMatchObject({
+      status: "complete",
+      usage: { iterations: 3, tokens: 1_300 },
+    });
+    runtime.close();
   });
 
   it("atomically aggregates superseding pending settlements", async () => {

--- a/agent-goal/sqlite-storage.test.ts
+++ b/agent-goal/sqlite-storage.test.ts
@@ -129,6 +129,26 @@ describe("SqliteGoalStorage", () => {
     expect(await storage.getPendingEvaluation("session-1")).toMatchObject({ goalVersion: 4 });
     expect(await storage.getTerminalCandidate("session-1")).toMatchObject({ goalVersion: 4 });
     expect(await storage.getContinuationClaim("session-1")).toMatchObject({ goalVersion: 4 });
+
+    expect(
+      await storage.appendPendingEvaluation({
+        ...pending,
+        evaluationId: "evaluation-late",
+        iterationsDelta: 2,
+      }),
+    ).toBe(true);
+    expect(await storage.getPendingEvaluation("session-1")).toMatchObject({
+      goalVersion: 4,
+      evaluationId: "evaluation-late",
+      iterationsDelta: 3,
+    });
+    expect(
+      await storage.replaceContinuationClaim({ ...claim, state: "started" }, claim.claimId),
+    ).toBe(true);
+    expect(await storage.getContinuationClaim("session-1")).toMatchObject({
+      goalVersion: 4,
+      state: "started",
+    });
     expect(await storage.updateBudget({ ...updated, version: 5 }, 3)).toBe(false);
     storage.close();
   });

--- a/agent-goal/sqlite-storage.ts
+++ b/agent-goal/sqlite-storage.ts
@@ -315,6 +315,68 @@ export class SqliteGoalStorage implements GoalStorage {
     return result.changes === 1;
   }
 
+  async updateBudget(goal: AgentGoal, expectedVersion: number): Promise<boolean> {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const result = this.db
+        .prepare(
+          `UPDATE agent_goals SET objective = ?, status = ?, blocked_reason = ?,
+           max_iterations = ?, max_tokens = ?, max_runtime_ms = ?, iterations_used = ?,
+           tokens_used = ?, last_settled_at = ?, last_evaluation_id = ?,
+           last_evaluation_outcome = ?, last_evaluation_reason = ?, last_evaluation_at = ?,
+           version = ?, updated_at = ?
+           WHERE scope_id = ? AND id = ? AND version = ?`,
+        )
+        .run(
+          goal.objective,
+          goal.status,
+          goal.blockedReason ?? null,
+          goal.budget.maxIterations,
+          goal.budget.maxTokens ?? null,
+          goal.budget.maxRuntimeMs ?? null,
+          goal.usage.iterations,
+          goal.usage.tokens,
+          goal.lastSettledAt ?? null,
+          goal.lastEvaluation?.id ?? null,
+          goal.lastEvaluation?.outcome ?? null,
+          goal.lastEvaluation?.reason ?? null,
+          goal.lastEvaluation?.at ?? null,
+          goal.version,
+          goal.updatedAt,
+          goal.scopeId,
+          goal.id,
+          expectedVersion,
+        );
+      if (result.changes !== 1) {
+        this.db.exec("ROLLBACK");
+        return false;
+      }
+      this.db
+        .prepare(
+          `UPDATE agent_goal_pending_evaluations SET goal_version = ?
+           WHERE scope_id = ? AND goal_id = ? AND goal_version = ?`,
+        )
+        .run(goal.version, goal.scopeId, goal.id, expectedVersion);
+      this.db
+        .prepare(
+          `UPDATE agent_goal_terminal_candidates SET goal_version = ?
+           WHERE scope_id = ? AND goal_id = ? AND goal_version = ?`,
+        )
+        .run(goal.version, goal.scopeId, goal.id, expectedVersion);
+      this.db
+        .prepare(
+          `UPDATE agent_goal_continuations SET goal_version = ?
+           WHERE scope_id = ? AND goal_id = ? AND goal_version = ?`,
+        )
+        .run(goal.version, goal.scopeId, goal.id, expectedVersion);
+      this.db.exec("COMMIT");
+      return true;
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
   async delete(scopeId: string, expectedVersion: number): Promise<boolean> {
     const result = this.db
       .prepare("DELETE FROM agent_goals WHERE scope_id = ? AND version = ?")

--- a/agent-goal/sqlite-storage.ts
+++ b/agent-goal/sqlite-storage.ts
@@ -419,10 +419,9 @@ export class SqliteGoalStorage implements GoalStorage {
          (scope_id, goal_id, goal_version, evaluation_id, iterations_delta, latest_output,
           token_delta, candidate_outcome, candidate_reason, attempt, available_at, last_error,
           created_at, updated_at)
-         SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-         WHERE EXISTS (
-           SELECT 1 FROM agent_goals WHERE scope_id = ? AND id = ? AND version = ?
-         )
+         SELECT ?, ?, goal.version, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+         FROM agent_goals AS goal
+         WHERE goal.scope_id = ? AND goal.id = ? AND goal.status = 'active'
          ON CONFLICT(scope_id) DO UPDATE SET goal_id = excluded.goal_id,
            goal_version = excluded.goal_version, evaluation_id = excluded.evaluation_id,
            iterations_delta = CASE
@@ -459,7 +458,6 @@ export class SqliteGoalStorage implements GoalStorage {
       .run(
         pending.scopeId,
         pending.goalId,
-        pending.goalVersion,
         pending.evaluationId,
         pending.iterationsDelta,
         pending.progress.latestOutput,
@@ -473,7 +471,6 @@ export class SqliteGoalStorage implements GoalStorage {
         pending.updatedAt,
         pending.scopeId,
         pending.goalId,
-        pending.goalVersion,
       );
     return result.changes === 1;
   }
@@ -742,13 +739,18 @@ export class SqliteGoalStorage implements GoalStorage {
   ): Promise<boolean> {
     const result = this.db
       .prepare(
-        `UPDATE agent_goal_continuations SET goal_id = ?, goal_version = ?, claim_id = ?,
-         state = ?, reason = ?, attempt = ?, available_at = ?, expires_at = ?,
-         last_error = ?, updated_at = ? WHERE scope_id = ? AND claim_id = ?`,
+        `UPDATE agent_goal_continuations SET goal_id = ?,
+         goal_version = (SELECT version FROM agent_goals WHERE scope_id = ? AND id = ?),
+         claim_id = ?, state = ?, reason = ?, attempt = ?, available_at = ?, expires_at = ?,
+         last_error = ?, updated_at = ? WHERE scope_id = ? AND claim_id = ?
+         AND goal_id = ? AND EXISTS (
+           SELECT 1 FROM agent_goals WHERE scope_id = ? AND id = ? AND status = 'active'
+         )`,
       )
       .run(
         claim.goalId,
-        claim.goalVersion,
+        claim.scopeId,
+        claim.goalId,
         claim.claimId,
         claim.state,
         claim.reason,
@@ -759,6 +761,9 @@ export class SqliteGoalStorage implements GoalStorage {
         claim.updatedAt,
         claim.scopeId,
         expectedClaimId,
+        claim.goalId,
+        claim.scopeId,
+        claim.goalId,
       );
     return result.changes === 1;
   }


### PR DESCRIPTION
## Summary

- add atomic optimistic turn/token budget updates to the standalone goal runtime
- expose operator `/goal budget turns=<n> tokens=<n>` controls
- expose model-visible `update_goal_budget` so the goal-bearing agent can adjust capacity
- preserve pending settlement, terminal-candidate, and continuation accounting across concurrent updates
- reactivate and continue budget-limited goals when new capacity is available
- emit `goal.budget_changed` and update documentation/headless guidance

## Guardrails

- updates remain within configured ceilings
- reductions cannot fall below accounted usage
- complete goals reject budget mutations
- stale CAS updates fail cleanly
- no usage or objective is reset

## Validation

- 65 agent-goal tests
- memory and SQLite atomicity coverage
- package lint/typecheck
- agent-standards lint
- full `pnpm prepush`
- `git diff --check`

Closes #1010
Related: #1009