### PR TITLE
feat(agent-goal): edit budgets in overlay

### DIFF
--- a/agent-goal/README.md
+++ b/agent-goal/README.md
@@ -30,7 +30,7 @@ pi -e ./agent-goal/index.ts
 /goal show         Show the compact persistent goal status
 ```
 
-Pi's footer is the only persistent goal UI and shows compact status and budget usage without duplicating the detailed dashboard. In interactive mode, `/goal` opens the detailed control window with the objective, lifecycle state, budget bars, latest evaluator guidance, and continuation state. Its visible keyboard actions pause or resume the goal, mark it complete, clear it, or close the window; complete and clear require a second keypress, and the window refreshes after state changes. Press Escape, `q`, or Ctrl+C to close it. `/goal` retains the detailed textual dashboard in headless sessions.
+Pi's footer is the only persistent goal UI and shows compact status and budget usage without duplicating the detailed dashboard. In interactive mode, `/goal` opens the detailed control window with the objective, lifecycle state, budget bars, latest evaluator guidance, and continuation state. Press `b` to edit total turn and token ceilings in place; digits edit the selected field, Tab switches fields, Enter saves, and Escape cancels. Other visible keyboard actions pause or resume the goal, mark it complete, clear it, or close the window; complete and clear require a second keypress, and validation errors remain visible in the open window. Press Escape, `q`, or Ctrl+C to close it. `/goal` retains the detailed textual dashboard in headless sessions.
 
 Only one goal may exist per Pi session. Clear the existing goal before creating another.
 

--- a/agent-goal/goal-window.test.ts
+++ b/agent-goal/goal-window.test.ts
@@ -57,7 +57,7 @@ describe("GoalWindow", () => {
     expect(lines.join("\n")).toContain("15m/60m");
     expect(lines.join("\n")).toContain("Latest Interaction tests remain");
     expect(lines.join("\n")).toContain("Continuation deferred · attempt 2");
-    expect(lines.join("\n")).toContain("p pause · c complete · x clear · q close");
+    expect(lines.join("\n")).toContain("p pause · b budget · c complete");
     expect(lines.every((line) => visibleWidth(line) <= 52)).toBe(true);
   });
 
@@ -97,6 +97,57 @@ describe("GoalWindow", () => {
     window.handleInput(input);
 
     expect(onAction).toHaveBeenCalledWith(action);
+  });
+
+  it("edits turn and token budgets without closing the overlay", () => {
+    const onAction = vi.fn();
+    const requestRender = vi.fn();
+    const window = new GoalWindow(goal, undefined, theme, onAction, requestRender);
+
+    window.handleInput("b");
+    expect(window.render(52).join("\n")).toContain("Edit budget");
+    expect(window.render(52).join("\n")).toContain("› Turns  8");
+
+    window.handleInput("1");
+    window.handleInput("\t");
+    window.handleInput("60000");
+    window.handleInput("\r");
+
+    expect(onAction).toHaveBeenCalledWith({
+      type: "budget",
+      maxIterations: 1,
+      maxTokens: 60_000,
+    });
+    expect(requestRender).toHaveBeenCalledTimes(4);
+  });
+
+  it("validates budget input and cancels editing with escape", () => {
+    const onAction = vi.fn();
+    const requestRender = vi.fn();
+    const window = new GoalWindow(goal, undefined, theme, onAction, requestRender);
+
+    window.handleInput("b");
+    window.handleInput("\u007f");
+    window.handleInput("\r");
+
+    expect(window.render(52).join("\n")).toContain("Turns must be a positive integer");
+    window.handleInput("\u001b");
+    expect(window.render(52).join("\n")).toContain("b budget");
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it("renders runtime budget errors inside the reopened overlay", () => {
+    const window = new GoalWindow(
+      goal,
+      undefined,
+      theme,
+      vi.fn(),
+      vi.fn(),
+      Date.now,
+      "Goal maxIterations cannot exceed the configured limit",
+    );
+
+    expect(window.render(52).join("\n")).toContain("Goal maxIterations cannot exceed the configur");
   });
 
   it("offers resume for paused and blocked goals", () => {

--- a/agent-goal/goal-window.ts
+++ b/agent-goal/goal-window.ts
@@ -23,12 +23,21 @@ function compactNumber(value: number): string {
   return `${scaled.toFixed(scaled < 100 ? 1 : 0).replace(/\.0$/, "")}${suffix}`;
 }
 
-export type GoalWindowAction = "pause" | "resume" | "complete" | "clear" | "close";
+export type GoalWindowLifecycleAction = "pause" | "resume" | "complete" | "clear" | "close";
+export type GoalWindowAction =
+  | GoalWindowLifecycleAction
+  | { type: "budget"; maxIterations: number; maxTokens?: number };
 
-type ConfirmableGoalWindowAction = Extract<GoalWindowAction, "complete" | "clear">;
+type ConfirmableGoalWindowAction = Extract<GoalWindowLifecycleAction, "complete" | "clear">;
+type BudgetField = "turns" | "tokens";
 
 export class GoalWindow implements Component {
   private pendingConfirmation: ConfirmableGoalWindowAction | undefined;
+  private budgetField: BudgetField | undefined;
+  private budgetTurns = "";
+  private budgetTokens = "";
+  private replaceBudgetValue = false;
+  private budgetInputError: string | undefined;
 
   constructor(
     private readonly goal: AgentGoal | undefined,
@@ -37,6 +46,7 @@ export class GoalWindow implements Component {
     private readonly onAction: (action: GoalWindowAction) => void,
     private readonly requestRender: () => void = () => undefined,
     private readonly now: () => number = Date.now,
+    private readonly actionError?: string,
   ) {}
 
   handleInput(data: string): void {
@@ -49,12 +59,51 @@ export class GoalWindow implements Component {
       if (this.pendingConfirmation) {
         this.pendingConfirmation = undefined;
         this.requestRender();
+      } else if (this.budgetField) {
+        this.budgetField = undefined;
+        this.budgetInputError = undefined;
+        this.requestRender();
       } else {
         this.onAction("close");
       }
       return;
     }
     if (!this.goal) return;
+
+    if (this.budgetField) {
+      if (matchesKey(data, "tab") || matchesKey(data, "up") || matchesKey(data, "down")) {
+        this.budgetField = this.budgetField === "turns" ? "tokens" : "turns";
+        this.replaceBudgetValue = true;
+        this.budgetInputError = undefined;
+      } else if (matchesKey(data, "backspace")) {
+        const value = this.budgetField === "turns" ? this.budgetTurns : this.budgetTokens;
+        if (this.budgetField === "turns") this.budgetTurns = value.slice(0, -1);
+        else this.budgetTokens = value.slice(0, -1);
+        this.replaceBudgetValue = false;
+        this.budgetInputError = undefined;
+      } else if (matchesKey(data, "enter")) {
+        const maxIterations = Number(this.budgetTurns);
+        if (!Number.isInteger(maxIterations) || maxIterations <= 0) {
+          this.budgetInputError = "Turns must be a positive integer";
+        } else {
+          const maxTokens = this.budgetTokens ? Number(this.budgetTokens) : undefined;
+          this.onAction({ type: "budget", maxIterations, maxTokens });
+          return;
+        }
+      } else if (/^\d+$/.test(data)) {
+        const value = this.replaceBudgetValue
+          ? data
+          : `${this.budgetField === "turns" ? this.budgetTurns : this.budgetTokens}${data}`;
+        if (this.budgetField === "turns") this.budgetTurns = value;
+        else this.budgetTokens = value;
+        this.replaceBudgetValue = false;
+        this.budgetInputError = undefined;
+      } else {
+        return;
+      }
+      this.requestRender();
+      return;
+    }
 
     if (this.pendingConfirmation) {
       const confirmationKey = this.pendingConfirmation === "complete" ? "c" : "x";
@@ -67,7 +116,15 @@ export class GoalWindow implements Component {
       return;
     }
 
-    if (key === "p" && this.goal.status === "active") {
+    if (key === "b" && this.goal.status !== "complete") {
+      this.budgetField = "turns";
+      this.budgetTurns = String(this.goal.budget.maxIterations);
+      this.budgetTokens =
+        this.goal.budget.maxTokens === undefined ? "" : String(this.goal.budget.maxTokens);
+      this.replaceBudgetValue = true;
+      this.budgetInputError = undefined;
+      this.requestRender();
+    } else if (key === "p" && this.goal.status === "active") {
       this.onAction("pause");
     } else if (key === "r" && (this.goal.status === "paused" || this.goal.status === "blocked")) {
       this.onAction("resume");
@@ -185,16 +242,32 @@ export class GoalWindow implements Component {
       );
     }
 
+    if (this.budgetField) {
+      const turns = `${this.budgetField === "turns" ? "›" : " "} Turns  ${this.budgetTurns || "_"}`;
+      const tokens = `${this.budgetField === "tokens" ? "›" : " "} Tokens ${this.budgetTokens || "unchanged"}`;
+      lines.push(
+        row(),
+        row(` ${this.theme.fg("accent", "Edit budget")}`),
+        row(` ${turns}`),
+        row(` ${tokens}`),
+      );
+    }
+    const error = this.budgetInputError ?? this.actionError;
+    if (error) lines.push(row(` ${this.theme.fg("error", displayGoalText(error, contentWidth))}`));
+
     const actions = [
       this.goal.status === "active" ? "p pause" : undefined,
       this.goal.status === "paused" || this.goal.status === "blocked" ? "r resume" : undefined,
+      this.goal.status !== "complete" ? "b budget" : undefined,
       this.goal.status !== "complete" ? "c complete" : undefined,
       "x clear",
       "q close",
     ].filter((action): action is string => action !== undefined);
     const footer = this.pendingConfirmation
       ? `${this.pendingConfirmation === "complete" ? "c" : "x"} again to confirm ${this.pendingConfirmation} · esc cancel`
-      : actions.join(" · ");
+      : this.budgetField
+        ? "digits edit · tab field · enter save · esc cancel"
+        : actions.join(" · ");
     lines.push(row(), row(` ${this.theme.fg("dim", footer)}`));
     lines.push(border(`╰${"─".repeat(innerWidth)}╯`));
     return lines;

--- a/agent-goal/index.test.ts
+++ b/agent-goal/index.test.ts
@@ -301,14 +301,24 @@ describe("registerAgentGoal", () => {
       createdAt: "2026-01-01T00:00:00.000Z",
       updatedAt: "2026-01-01T00:00:00.000Z",
     });
-    const actions: GoalWindowAction[] = ["pause", "close"];
+    const actions: GoalWindowAction[] = [
+      { type: "budget", maxIterations: 1, maxTokens: 10 },
+      { type: "budget", maxIterations: 4, maxTokens: 1_000 },
+      "pause",
+      "close",
+    ];
+    let customCall = 0;
     const custom = vi.fn(async (factory: GoalWindowFactory) => {
-      factory(
+      const component = factory(
         { requestRender: vi.fn() },
         { fg: (_color, text) => text, bold: (text) => text } as Theme,
         {},
         vi.fn(),
       );
+      customCall += 1;
+      if (customCall === 2) {
+        expect(component.render(66).join("\n")).toContain("current turn");
+      }
       return actions.shift();
     });
     const setStatus = vi.fn();
@@ -329,9 +339,15 @@ describe("registerAgentGoal", () => {
 
     expect(setStatus).toHaveBeenCalledWith("agent-goal", "goal: active · 1/5 turns");
     expect(setWidget).toHaveBeenCalledWith("agent-goal", undefined);
-    expect(custom).toHaveBeenCalledTimes(2);
-    expect(await storage.get("session-1")).toMatchObject({ status: "paused" });
-    expect(setStatus).toHaveBeenLastCalledWith("agent-goal", "goal: paused · 1/5 turns");
+    expect(custom).toHaveBeenCalledTimes(4);
+    expect(await storage.get("session-1")).toMatchObject({
+      status: "paused",
+      budget: { maxIterations: 4, maxTokens: 1_000 },
+    });
+    expect(setStatus).toHaveBeenLastCalledWith(
+      "agent-goal",
+      "goal: paused · 1/4 turns · 10/1000 tok",
+    );
   });
 
   it.each(["complete", "blocked"] as const)(

--- a/agent-goal/index.ts
+++ b/agent-goal/index.ts
@@ -2,7 +2,11 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { formatGoalDashboard, formatGoalStatus } from "./dashboard.js";
-import { GoalWindow, type GoalWindowAction } from "./goal-window.js";
+import {
+  GoalWindow,
+  type GoalWindowAction,
+  type GoalWindowLifecycleAction,
+} from "./goal-window.js";
 import type {
   GoalBudget,
   GoalContinuation,
@@ -44,7 +48,11 @@ export type {
   GoalWakeScheduler,
 } from "./domain.js";
 export { displayGoalText, formatGoalDashboard, formatGoalStatus } from "./dashboard.js";
-export { GoalWindow, type GoalWindowAction } from "./goal-window.js";
+export {
+  GoalWindow,
+  type GoalWindowAction,
+  type GoalWindowLifecycleAction,
+} from "./goal-window.js";
 export { MemoryGoalStorage } from "./memory-storage.js";
 export { parseGoalEvaluation, PiGoalEvaluator } from "./pi-evaluator.js";
 export {
@@ -169,8 +177,15 @@ export function registerAgentGoal(pi: ExtensionAPI, options: AgentGoalExtensionO
 
   const applyGoalAction = async (
     scopeId: string,
-    action: Exclude<GoalWindowAction, "close">,
+    action: Exclude<GoalWindowLifecycleAction, "close"> | Extract<GoalWindowAction, object>,
   ): Promise<void> => {
+    if (typeof action === "object") {
+      await runtime.updateBudget(scopeId, {
+        maxIterations: action.maxIterations,
+        maxTokens: action.maxTokens,
+      });
+      return;
+    }
     switch (action) {
       case "pause":
         await runtime.setStatus(scopeId, "paused");
@@ -464,13 +479,22 @@ export function registerAgentGoal(pi: ExtensionAPI, options: AgentGoalExtensionO
       try {
         if (!input) {
           let openedWindow = false;
+          let actionError: string | undefined;
           while (true) {
             const goal = await runtime.get(scopeId);
             const claim = await runtime.getContinuationClaim(scopeId);
             const action = await ctx.ui.custom<GoalWindowAction>(
               (tui, theme, _keybindings, done) => {
                 openedWindow = true;
-                return new GoalWindow(goal, claim, theme, done, () => tui.requestRender());
+                return new GoalWindow(
+                  goal,
+                  claim,
+                  theme,
+                  done,
+                  () => tui.requestRender(),
+                  Date.now,
+                  actionError,
+                );
               },
               {
                 overlay: true,
@@ -497,8 +521,13 @@ export function registerAgentGoal(pi: ExtensionAPI, options: AgentGoalExtensionO
               return;
             }
             if (!action || action === "close") return;
-            await applyGoalAction(scopeId, action);
-            await refreshUi(ctx);
+            try {
+              await applyGoalAction(scopeId, action);
+              actionError = undefined;
+              await refreshUi(ctx);
+            } catch (error) {
+              actionError = error instanceof Error ? error.message : String(error);
+            }
           }
         }
 


### PR DESCRIPTION
Closes #1012.

## Summary
- add an in-overlay turn/token budget editor behind `b`
- route saves through `GoalRuntime.updateBudget()`
- keep validation failures visible and reopen the refreshed overlay after updates
- retain the compact passive footer and headless command behavior

## Validation
- `pnpm prepush`
- 71 agent-goal tests
- `git diff --check`