### PR TITLE
fix(agent-goal): start idle goals with pending delivery

### DIFF
--- a/agent-goal/index.test.ts
+++ b/agent-goal/index.test.ts
@@ -103,6 +103,57 @@ describe("registerAgentGoal", () => {
     },
   );
 
+  it("starts an operator-created goal when the idle session reports pending delivery", async () => {
+    const handlers = new Map<string, GoalEventHandler>();
+    const commands = new Map<string, RegisteredCommand>();
+    const sendMessage = vi.fn();
+    const pi = {
+      on(name: string, handler: GoalEventHandler) {
+        handlers.set(name, handler);
+      },
+      registerTool: vi.fn(),
+      registerCommand(name: string, command: RegisteredCommand) {
+        commands.set(name, command);
+      },
+      sendMessage,
+    } as object as ExtensionAPI;
+    const context = {
+      hasUI: true,
+      isIdle: () => true,
+      hasPendingMessages: () => true,
+      sessionManager: { getSessionId: () => "session-1" },
+      ui: {
+        setStatus: vi.fn(),
+        setWidget: vi.fn(),
+        notify: vi.fn(),
+      },
+    } as object as ExtensionCommandContext;
+    const storage = new MemoryGoalStorage();
+    registerAgentGoal(pi, {
+      storage,
+      evaluator: {
+        evaluate: vi.fn().mockResolvedValue({ outcome: "complete", reason: "verified" }),
+      },
+    });
+    const command = commands.get("goal");
+    if (!command) throw new Error("goal command was not registered");
+
+    await command.handler("verify operator goal start", context);
+
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(await storage.getContinuationClaim("session-1")).toMatchObject({ state: "started" });
+
+    await handlers.get("agent_start")?.({}, context);
+    await handlers.get("agent_end")?.({ messages: [] }, context);
+    await handlers.get("agent_settled")?.({}, context);
+
+    expect(await storage.get("session-1")).toMatchObject({
+      status: "complete",
+      usage: { iterations: 1, tokens: 0 },
+    });
+    await handlers.get("session_shutdown")?.({}, context);
+  });
+
   it("automatically retries a continuation deferred while the session is busy", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));

--- a/agent-goal/index.ts
+++ b/agent-goal/index.ts
@@ -136,7 +136,7 @@ export function registerAgentGoal(pi: ExtensionAPI, options: AgentGoalExtensionO
         if (!ctx || ctx.sessionManager.getSessionId() !== goal.scopeId) {
           return { status: "unavailable", reason: "The goal session is not active" };
         }
-        if (!ctx.isIdle() || ctx.hasPendingMessages()) {
+        if (!ctx.isIdle()) {
           return { status: "busy", reason: "The goal session is busy", retryAfterMs: 1_000 };
         }
         api.sendMessage(


### PR DESCRIPTION
Closes #1014.

## Summary
- treat Pi `isIdle()` as authoritative for goal initiation
- do not strand operator-created goals on an idle session whose pending-delivery flag remains set
- add a red/green regression that initiates the goal and verifies exactly one settled turn is charged

## Evidence
- Before fix: new regression failed because `sendMessage` was called 0 times.
- After fix: 72/72 agent-goal tests pass and the run settles at exactly one iteration.
- Separate live-panel clean-idle smoke test initiated immediately and executed one model turn.
- Full `pnpm prepush` and `git diff --check` pass.