### PR TITLE
chore: release 0.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ themselves create a new release entry, tag, or package version. Add a versioned
 entry only when a maintainer approves a real release with intentional package
 version bumps and publish scope.
 
+## [0.2.11] - 2026-08-25
+
+Pinet v0.2.11 adds safe mutable budgets and reliable operator-driven initiation to the standalone single-session goal loop.
+
+### Version verification
+
+- `pi-extensions` — `0.2.11` (private repo package)
+- `@pinet/transport-core` — `0.2.11`
+- `@pinet/broker-core` — `0.2.11`
+- `@pinet/pinet-core` — `0.2.11`
+- `@pinet/imessage-bridge` — `0.2.11`
+- `@pinet/slack-bridge` — `0.2.11`
+- `@pinet/model-aware-compaction` — `0.2.11`
+- `@pinet/agent-goal` — `0.2.11`
+
+### Release highlights
+
+- Adds atomic, bounded goal turn/token budget updates for operators and agents without recreating a goal or losing accounted usage.
+- Rebinds pending evaluations and continuation claims across budget-version changes, including deterministic memory and SQLite race coverage.
+- Adds turn/token budget editing to the interactive `/goal` overlay with in-place validation and refresh.
+- Starts operator-created goals when Pi is idle even if pending delivery is reported, while preserving one charge per `agent_settled` run.
+
+### Notable pull requests
+
+- [#1011](https://github.com/gugu91/pinet/pull/1011) — add mutable goal budgets and close concurrent settlement/continuation races
+- [#1013](https://github.com/gugu91/pinet/pull/1013) — edit goal budgets from the interactive overlay
+- [#1015](https://github.com/gugu91/pinet/pull/1015) — prevent idle operator-created goals from stalling on pending delivery
+
+See the [full change set since v0.2.10](https://github.com/gugu91/pinet/compare/v0.2.10...v0.2.11).
+
 ## [0.2.10] - 2026-08-23
 
 Pinet v0.2.10 prevents model-aware proactive compaction from racing Pi's native auto-compaction lifecycle.

--- a/agent-goal/package.json
+++ b/agent-goal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/agent-goal",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "type": "module",
   "description": "Standalone single-agent durable goal loop for Pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/broker-core",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "type": "module",
   "description": "Transport-neutral broker kernel primitives for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/imessage-bridge",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "type": "module",
   "description": "macOS/iMessage send-first adapter and readiness helpers for pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/model-aware-compaction/package.json
+++ b/model-aware-compaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/model-aware-compaction",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "type": "module",
   "description": "Pi extension for proactive model-aware context compaction thresholds",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/pinet-core",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "type": "module",
   "description": "Pinet runtime core for pi — broker/follower orchestration and mesh tooling",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/slack-bridge",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "type": "module",
   "description": "Pi package for Pinet Slack assistant integration — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/transport-core",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "type": "module",
   "description": "Transport-neutral message contracts for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
Closes #1017.

## Summary
- bump the private root and all seven public `@pinet/*` packages to `0.2.11`
- document mutable goal budgets, overlay editing, race safety, and reliable idle initiation

## Validation
- `pnpm prepush`
- `pnpm publish:npm` coordinated seven-package dry-run
- `git diff --check`

After merge: create annotated `v0.2.11`, publish via protected Trusted Publishing, and registry-verify all seven packages.