### PR TITLE
chore: release 0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ themselves create a new release entry, tag, or package version. Add a versioned
 entry only when a maintainer approves a real release with intentional package
 version bumps and publish scope.
 
+## [0.2.12] - 2026-08-26
+
+Pinet v0.2.12 replaces the dormant PiComms review store with Pinet-native, revision-aware contextual threads for single-file Neovim diffs.
+
+### Version verification
+
+- `pi-extensions` — `0.2.12` (private repo package)
+- `@pinet/transport-core` — `0.2.12`
+- `@pinet/broker-core` — `0.2.12`
+- `@pinet/pinet-core` — `0.2.12`
+- `@pinet/imessage-bridge` — `0.2.12`
+- `@pinet/slack-bridge` — `0.2.12`
+- `@pinet/model-aware-compaction` — `0.2.12`
+- `@pinet/agent-goal` — `0.2.12`
+
+### Release highlights
+
+- Adds persisted line/range-anchored contextual threads to existing single-file Fugitive and native Neovim diffs without introducing a review-specific service or second database.
+- Stores comments, replies, resolution state, and revision-aware anchors as ordinary Pinet threads/messages in BrokerDB, restoring matching open and resolved signs after restarts.
+- Routes explicit Neovim comments through normal Pinet agent inboxes, supports generic agent thread replies, and hydrates a bounded summary of relevant unresolved threads into later agent turns.
+- Preserves `open_in_editor` and editor-context sync through the broker-owned Unix socket with canonical worktree-relative paths, including subdirectory sessions and native old-side snapshots.
+- Removes the legacy PiComms SQLite/filesystem persistence, RPC surface, and canonical `ctx:<file>:<range>` identities.
+
+### Notable pull requests
+
+- [#1019](https://github.com/gugu91/pinet/pull/1019) — add Pinet-native Neovim contextual threads and replace the dormant PiComms subsystem
+
+See the [full change set since v0.2.11](https://github.com/gugu91/pinet/compare/v0.2.11...v0.2.12).
+
 ## [0.2.11] - 2026-08-25
 
 Pinet v0.2.11 adds safe mutable budgets and reliable operator-driven initiation to the standalone single-session goal loop.

--- a/agent-goal/package.json
+++ b/agent-goal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/agent-goal",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "description": "Standalone single-agent durable goal loop for Pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/broker-core",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "description": "Transport-neutral broker kernel primitives for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/imessage-bridge",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "description": "macOS/iMessage send-first adapter and readiness helpers for pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/model-aware-compaction/package.json
+++ b/model-aware-compaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/model-aware-compaction",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "description": "Pi extension for proactive model-aware context compaction thresholds",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/pinet-core",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "description": "Pinet runtime core for pi — broker/follower orchestration and mesh tooling",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/slack-bridge",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "description": "Pi package for Pinet Slack assistant integration — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/transport-core",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "description": "Transport-neutral message contracts for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
Closes #1020.

## Summary
- bump the private root and all seven public `@pinet/*` packages to `0.2.12`
- document the Pinet-native Neovim contextual-thread integration from #1019

## Validation
- `pnpm prepush`
- `pnpm publish:npm` coordinated seven-package dry-run
- `node scripts/validate-npm-tag-version.mjs refs/tags/v0.2.12`
- registry preflight confirms `0.2.12` is unpublished for all seven packages
- `git diff --check`

After merge: tag current `main` as `v0.2.12`, create the GitHub release, let the protected Trusted Publishing workflow publish all seven packages, then registry-verify each version.