### PR TITLE
feat: add document ownership and subscriptions

### DIFF
--- a/broker-core/hibernation-schema.test.ts
+++ b/broker-core/hibernation-schema.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
-import { BrokerDB } from "./schema.js";
+import { BrokerDB, CURRENT_BROKER_SCHEMA_VERSION } from "./schema.js";
 import type { AgentLifecycleState, AgentRuntimeSpecInput } from "./types.js";
 
 function driveTo(db: BrokerDB, agentId: string, path: AgentLifecycleState[]): void {
@@ -165,7 +165,7 @@ function herdrSpec(agentId: string): AgentRuntimeSpecInput {
 }
 
 describe("runtime spec persistence", () => {
-  it("creates fresh v24 databases with exact per-kind payload constraints", () => {
+  it("creates fresh databases with exact per-kind payload constraints", () => {
     const path = dbPath();
     const db = new BrokerDB(path);
     db.initialize();
@@ -200,7 +200,7 @@ describe("runtime spec persistence", () => {
       expect(table.sql).toContain("herdr_session IS NULL");
       expect(table.sql).toContain("tmux_socket IS NULL");
       const version = sqlite.prepare("PRAGMA user_version").get() as { user_version: number };
-      expect(version.user_version).toBe(24);
+      expect(version.user_version).toBe(CURRENT_BROKER_SCHEMA_VERSION);
     } finally {
       sqlite.close();
       db.close();
@@ -245,7 +245,7 @@ describe("runtime spec persistence", () => {
         });
 
         const version = sqlite.prepare("PRAGMA user_version").get() as { user_version: number };
-        expect(version.user_version).toBe(24);
+        expect(version.user_version).toBe(CURRENT_BROKER_SCHEMA_VERSION);
       } finally {
         sqlite.close();
       }

--- a/broker-core/message-send.ts
+++ b/broker-core/message-send.ts
@@ -10,6 +10,7 @@ import type {
 
 export interface BrokerMessageSenderDb {
   getThread(threadId: string): ThreadInfo | null;
+  getDocumentRecipients?(documentId: string): string[];
   createThread(
     threadId: string,
     source: string,
@@ -141,14 +142,24 @@ export async function sendBrokerMessage(
   };
   await adapter.send(outbound);
 
+  const documentId =
+    typeof thread.metadata?.documentId === "string" ? thread.metadata.documentId : null;
+  const documentRecipients = documentId
+    ? (deps.db.getDocumentRecipients?.(documentId) ?? []).filter(
+        (agentId) => agentId !== input.senderAgentId,
+      )
+    : [];
   const message = deps.db.insertMessage(
     threadId,
     source,
     "outbound",
     input.senderAgentId,
     messageBody,
-    [],
-    input.metadata,
+    [...new Set(documentRecipients)],
+    {
+      ...(input.metadata ?? {}),
+      ...(documentId ? { documentId } : {}),
+    },
   );
 
   return {

--- a/broker-core/router.ts
+++ b/broker-core/router.ts
@@ -342,6 +342,30 @@ export class MessageRouter {
       }
     }
 
+    const messageDocumentId =
+      typeof msg.metadata?.documentId === "string" ? msg.metadata.documentId : null;
+    const threadDocumentId =
+      typeof thread?.metadata?.documentId === "string" ? thread.metadata.documentId : null;
+    const documentId = messageDocumentId ?? threadDocumentId;
+    if (documentId) {
+      const document = this.db.getDocument?.(documentId) ?? null;
+      if (
+        thread?.ownerAgent &&
+        document &&
+        document.ownerAgent !== thread.ownerAgent &&
+        this.db.setDocumentOwner
+      ) {
+        this.db.setDocumentOwner(documentId, thread.ownerAgent);
+      }
+      const recipientIds = (this.db.getDocumentRecipients?.(documentId) ?? [])
+        .map((agentId) => agents.find((agent) => agent.id === agentId) ?? null)
+        .filter((agent): agent is AgentInfo => agent !== null && isRoutableOwner(agent))
+        .map((agent) => agent.id);
+      const recipients = [...new Set(recipientIds)];
+      if (recipients.length === 1) return { action: "deliver", agentId: recipients[0]! };
+      if (recipients.length > 1) return { action: "broadcast", agentIds: recipients };
+    }
+
     if (thread) {
       if (thread.ownerBinding === "explicit") {
         const explicitOwner = resolveRoutableThreadOwner(this.db, thread.ownerAgent);

--- a/broker-core/router.ts
+++ b/broker-core/router.ts
@@ -358,8 +358,8 @@ export class MessageRouter {
         this.db.setDocumentOwner(documentId, thread.ownerAgent);
       }
       const recipientIds = (this.db.getDocumentRecipients?.(documentId) ?? [])
-        .map((agentId) => agents.find((agent) => agent.id === agentId) ?? null)
-        .filter((agent): agent is AgentInfo => agent !== null && isRoutableOwner(agent))
+        .map((agentId) => resolveRoutableThreadOwner(this.db, agentId))
+        .filter((agent): agent is AgentInfo => agent !== null)
         .map((agent) => agent.id);
       const recipients = [...new Set(recipientIds)];
       if (recipients.length === 1) return { action: "deliver", agentId: recipients[0]! };

--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -1701,6 +1701,50 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("persists document ownership, aliases, and deduplicated subscriptions", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    const dbPath = path.join(dir, "broker.db");
+    try {
+      db.upsertDocument({
+        documentId: "doc:git-file:test",
+        kind: "git_file",
+        title: "src/app.ts",
+        ownerAgent: "owner",
+        ownerBinding: "explicit",
+        metadata: { path: "src/app.ts" },
+      });
+      db.bindDocumentAlias("nvim", "repo\\0worktree\\0src/app.ts", "doc:git-file:test");
+      db.subscribeDocument("doc:git-file:test", "subscriber");
+      db.subscribeDocument("doc:git-file:test", "owner");
+      expect(db.getDocumentByAlias("nvim", "repo\\0worktree\\0src/app.ts")).toMatchObject({
+        documentId: "doc:git-file:test",
+        ownerAgent: "owner",
+      });
+      expect(db.getDocumentRecipients("doc:git-file:test")).toEqual(["owner", "subscriber"]);
+      db.close();
+
+      const restarted = new BrokerDB(dbPath);
+      restarted.initialize();
+      expect(restarted.getDocument("doc:git-file:test")?.metadata).toEqual({
+        path: "src/app.ts",
+      });
+      expect(restarted.listDocumentSubscribers("doc:git-file:test")).toEqual([
+        "owner",
+        "subscriber",
+      ]);
+      restarted.unsubscribeDocument("doc:git-file:test", "owner");
+      restarted.setDocumentOwner("doc:git-file:test", "new-owner");
+      expect(restarted.getDocumentRecipients("doc:git-file:test")).toEqual([
+        "new-owner",
+        "subscriber",
+      ]);
+      restarted.close();
+    } finally {
+      db.close();
+    }
+  });
+
   it("acquires requested and allocated port leases with active uniqueness", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);

--- a/broker-core/schema.test.ts
+++ b/broker-core/schema.test.ts
@@ -1701,6 +1701,54 @@ describe("BrokerDB message sync identity", () => {
     }
   });
 
+  it("migrates an existing v24 broker database to document schema v25", () => {
+    const { db, dir } = createDb();
+    cleanupDirs.push(dir);
+    const dbPath = path.join(dir, "broker.db");
+    db.createThread("existing-thread", "slack", "C123", "agent-1");
+    db.close();
+
+    const legacy = new DatabaseSync(dbPath);
+    try {
+      legacy.exec(`
+        DROP TABLE document_subscriptions;
+        DROP TABLE document_aliases;
+        DROP TABLE documents;
+        PRAGMA user_version = 24;
+      `);
+    } finally {
+      legacy.close();
+    }
+
+    const upgraded = new BrokerDB(dbPath);
+    try {
+      upgraded.initialize();
+      expect(upgraded.getThread("existing-thread")).toMatchObject({ ownerAgent: "agent-1" });
+      expect(upgraded.getDocument("doc:missing")).toBeNull();
+      upgraded.upsertDocument({
+        documentId: "doc:git-file:migrated",
+        kind: "git_file",
+        title: "README.md",
+        ownerAgent: "agent-1",
+        ownerBinding: "explicit",
+        metadata: null,
+      });
+      expect(upgraded.getDocument("doc:git-file:migrated")?.title).toBe("README.md");
+    } finally {
+      upgraded.close();
+    }
+
+    const versionDb = new DatabaseSync(dbPath);
+    try {
+      const version = versionDb.prepare("PRAGMA user_version").get() as {
+        user_version?: number;
+      };
+      expect(version.user_version).toBe(CURRENT_BROKER_SCHEMA_VERSION);
+    } finally {
+      versionDb.close();
+    }
+  });
+
   it("persists document ownership, aliases, and deduplicated subscriptions", () => {
     const { db, dir } = createDb();
     cleanupDirs.push(dir);

--- a/broker-core/schema.ts
+++ b/broker-core/schema.ts
@@ -11,6 +11,8 @@ import type {
   AgentInfo,
   AgentSupervisionState,
   ThreadInfo,
+  DocumentAliasInfo,
+  DocumentInfo,
   BrokerMessage,
   InboxEntry,
   InboxReadOptions,
@@ -122,6 +124,17 @@ interface ThreadRow {
   thread_id: string;
   source: string;
   channel: string;
+  owner_agent: string | null;
+  owner_binding: string | null;
+  metadata: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface DocumentRow {
+  document_id: string;
+  kind: string;
+  title: string;
   owner_agent: string | null;
   owner_binding: string | null;
   metadata: string | null;
@@ -273,6 +286,22 @@ function rowToThread(row: ThreadRow): ThreadInfo {
     ownerAgent: row.owner_agent,
     ownerBinding: row.owner_binding === "explicit" ? "explicit" : null,
     metadata: row.metadata ? (JSON.parse(row.metadata) as Record<string, unknown>) : null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function rowToDocument(row: DocumentRow): DocumentInfo {
+  const kind = row.kind === "slack_thread" || row.kind === "slack_channel" ? row.kind : "git_file";
+  return {
+    documentId: row.document_id,
+    kind,
+    title: row.title,
+    ownerAgent: row.owner_agent,
+    ownerBinding: row.owner_binding === "explicit" ? "explicit" : null,
+    metadata: row.metadata
+      ? (JSON.parse(row.metadata) as NonNullable<DocumentInfo["metadata"]>)
+      : null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -957,7 +986,7 @@ export function defaultDbPath(): string {
 
 export const DEFAULT_RESUMABLE_WINDOW_MS = 15_000;
 export const DEFAULT_DISCONNECTED_PURGE_GRACE_MS = 60 * 60_000;
-export const CURRENT_BROKER_SCHEMA_VERSION = 24;
+export const CURRENT_BROKER_SCHEMA_VERSION = 25;
 
 /**
  * Lifecycle states whose durable identity, inbox, thread ownership, and runtime
@@ -1940,6 +1969,42 @@ function widenRuntimeSpecPayload(db: DatabaseSync): void {
   `);
 }
 
+// agent-standards-ignore prefer-inline-single-use-helper: one-function-per-migration-case is the established schema-migration seam.
+function createDocumentTables(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS documents (
+      document_id TEXT PRIMARY KEY NOT NULL,
+      kind TEXT NOT NULL CHECK(kind IN ('git_file','slack_thread','slack_channel')),
+      title TEXT NOT NULL,
+      owner_agent TEXT,
+      owner_binding TEXT,
+      metadata TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS document_aliases (
+      source TEXT NOT NULL,
+      external_id TEXT NOT NULL,
+      document_id TEXT NOT NULL,
+      metadata TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY(source, external_id),
+      FOREIGN KEY(document_id) REFERENCES documents(document_id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS document_subscriptions (
+      document_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY(document_id, agent_id),
+      FOREIGN KEY(document_id) REFERENCES documents(document_id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_document_subscriptions_agent
+      ON document_subscriptions(agent_id, document_id);
+  `);
+}
+
 function runSchemaMigrations(db: DatabaseSync): void {
   const currentVersion = getUserVersion(db);
   if (currentVersion >= CURRENT_BROKER_SCHEMA_VERSION) {
@@ -2025,6 +2090,9 @@ function runSchemaMigrations(db: DatabaseSync): void {
           break;
         case 24:
           widenRuntimeSpecPayload(db);
+          break;
+        case 25:
+          createDocumentTables(db);
           break;
         default:
           throw new Error(`Unsupported broker schema migration target: ${nextVersion}`);
@@ -4415,6 +4483,127 @@ export class BrokerDB implements BrokerDBInterface {
     return row ?? null;
   }
 
+  // ─── Documents ───────────────────────────────────────
+
+  getDocument(documentId: string): DocumentInfo | null {
+    const row = this.getDb()
+      .prepare("SELECT * FROM documents WHERE document_id = ?")
+      .get(documentId) as DocumentRow | undefined;
+    return row ? rowToDocument(row) : null;
+  }
+
+  getDocumentByAlias(source: string, externalId: string): DocumentInfo | null {
+    const row = this.getDb()
+      .prepare(
+        `SELECT d.* FROM documents d
+         JOIN document_aliases a ON a.document_id = d.document_id
+         WHERE a.source = ? AND a.external_id = ?`,
+      )
+      .get(source, externalId) as DocumentRow | undefined;
+    return row ? rowToDocument(row) : null;
+  }
+
+  upsertDocument(document: Omit<DocumentInfo, "createdAt" | "updatedAt">): DocumentInfo {
+    const db = this.getDb();
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO documents
+       (document_id, kind, title, owner_agent, owner_binding, metadata, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(document_id) DO UPDATE SET
+         kind = excluded.kind,
+         title = excluded.title,
+         metadata = excluded.metadata,
+         updated_at = excluded.updated_at`,
+    ).run(
+      document.documentId,
+      document.kind,
+      document.title,
+      document.ownerAgent,
+      document.ownerBinding,
+      document.metadata ? JSON.stringify(document.metadata) : null,
+      now,
+      now,
+    );
+    return this.getDocument(document.documentId)!;
+  }
+
+  bindDocumentAlias(
+    source: string,
+    externalId: string,
+    documentId: string,
+    metadata: DocumentInfo["metadata"] = null,
+  ): DocumentAliasInfo {
+    const db = this.getDb();
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO document_aliases
+       (source, external_id, document_id, metadata, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(source, external_id) DO UPDATE SET
+         document_id = excluded.document_id,
+         metadata = excluded.metadata,
+         updated_at = excluded.updated_at`,
+    ).run(source, externalId, documentId, metadata ? JSON.stringify(metadata) : null, now, now);
+    return {
+      source,
+      externalId,
+      documentId,
+      metadata,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  setDocumentOwner(documentId: string, ownerAgent: string | null): DocumentInfo {
+    const db = this.getDb();
+    const result = db
+      .prepare(
+        `UPDATE documents SET owner_agent = ?, owner_binding = 'explicit', updated_at = ?
+         WHERE document_id = ?`,
+      )
+      .run(ownerAgent, new Date().toISOString(), documentId);
+    if (Number(result.changes ?? 0) === 0) throw new Error(`Unknown document ${documentId}`);
+    return this.getDocument(documentId)!;
+  }
+
+  subscribeDocument(documentId: string, agentId: string): void {
+    const now = new Date().toISOString();
+    this.getDb()
+      .prepare(
+        `INSERT INTO document_subscriptions (document_id, agent_id, created_at, updated_at)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(document_id, agent_id) DO UPDATE SET updated_at = excluded.updated_at`,
+      )
+      .run(documentId, agentId, now, now);
+  }
+
+  unsubscribeDocument(documentId: string, agentId: string): void {
+    this.getDb()
+      .prepare("DELETE FROM document_subscriptions WHERE document_id = ? AND agent_id = ?")
+      .run(documentId, agentId);
+  }
+
+  listDocumentSubscribers(documentId: string): string[] {
+    const rows = this.getDb()
+      .prepare(
+        "SELECT agent_id FROM document_subscriptions WHERE document_id = ? ORDER BY agent_id",
+      )
+      .all(documentId) as Array<{ agent_id: string }>;
+    return rows.map((row) => row.agent_id);
+  }
+
+  getDocumentRecipients(documentId: string): string[] {
+    const document = this.getDocument(documentId);
+    if (!document) return [];
+    return [
+      ...new Set([
+        ...(document.ownerAgent ? [document.ownerAgent] : []),
+        ...this.listDocumentSubscribers(documentId),
+      ]),
+    ];
+  }
+
   // ─── Threads ─────────────────────────────────────────
 
   createThread(thread: ThreadInfo): ThreadInfo;
@@ -5557,6 +5746,23 @@ export class BrokerDB implements BrokerDBInterface {
         message.userId,
         message.text,
         [agentId],
+        this.buildInboundMessageMetadata(message),
+      );
+      this.reclassifyReferencedMessageFromReaction(message);
+    });
+  }
+
+  queueMessageToAgents(agentIds: string[], message: InboundMessage): void {
+    const recipients = [...new Set(agentIds.filter((agentId) => agentId.length > 0))];
+    if (recipients.length === 0) return;
+    this.withTransaction(() => {
+      this.insertMessage(
+        message.threadId,
+        message.source,
+        "inbound",
+        message.userId,
+        message.text,
+        recipients,
         this.buildInboundMessageMetadata(message),
       );
       this.reclassifyReferencedMessageFromReaction(message);

--- a/broker-core/types.ts
+++ b/broker-core/types.ts
@@ -417,6 +417,26 @@ export interface ThreadInfo {
   updatedAt: string;
 }
 
+export interface DocumentInfo {
+  documentId: string;
+  kind: "git_file" | "slack_thread" | "slack_channel";
+  title: string;
+  ownerAgent: string | null;
+  ownerBinding: "explicit" | null;
+  metadata: ThreadInfo["metadata"];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface DocumentAliasInfo {
+  source: string;
+  externalId: string;
+  documentId: string;
+  metadata: ThreadInfo["metadata"];
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface BrokerMessage {
   id: number;
   threadId: string;
@@ -755,6 +775,20 @@ export const buildRuntimeScopeCarrier = _buildRuntimeScopeCarrier;
 
 export interface BrokerDBInterface {
   getThread(threadId: string): ThreadInfo | null;
+  getDocument?(documentId: string): DocumentInfo | null;
+  getDocumentByAlias?(source: string, externalId: string): DocumentInfo | null;
+  upsertDocument?(document: Omit<DocumentInfo, "createdAt" | "updatedAt">): DocumentInfo;
+  bindDocumentAlias?(
+    source: string,
+    externalId: string,
+    documentId: string,
+    metadata?: ThreadInfo["metadata"],
+  ): DocumentAliasInfo;
+  setDocumentOwner?(documentId: string, ownerAgent: string | null): DocumentInfo;
+  subscribeDocument?(documentId: string, agentId: string): void;
+  unsubscribeDocument?(documentId: string, agentId: string): void;
+  listDocumentSubscribers?(documentId: string): string[];
+  getDocumentRecipients?(documentId: string): string[];
   getAgentById(agentId: string): AgentInfo | null;
   getAgentByStableId(stableId: string): AgentInfo | null;
   getAgents(): AgentInfo[];
@@ -785,4 +819,5 @@ export interface BrokerDBInterface {
   claimThread(threadId: string, agentId: string, source?: string, channel?: string): boolean;
 
   queueMessage(agentId: string, message: InboundMessage): void;
+  queueMessageToAgents?(agentIds: string[], message: InboundMessage): void;
 }

--- a/nvim-bridge/README.md
+++ b/nvim-bridge/README.md
@@ -43,6 +43,7 @@ Contextual thread commands:
 - `:PinetSubscribe [agent_id]` — subscribe an agent to document thread activity.
 - `:PinetUnsubscribe [agent_id]` — remove a document subscription.
 - `:PinetSubscribers` — show the document owner and subscribers.
+- `:PinetBindSlack <thread_id>` — explicitly bind an existing Slack thread to the current tracked document so both adapters share ownership and subscriptions.
 
 Document ownership and subscriptions are persisted in BrokerDB and shared across adapters. Slack threads are bound to the same document-domain ports through aliases; transports do not maintain separate ownership tables. Subscriptions grant delivery, not thread-ownership or reply authority.
 

--- a/nvim-bridge/README.md
+++ b/nvim-bridge/README.md
@@ -9,8 +9,10 @@ The durable integration is hosted by the active Pinet broker as a `MessageAdapte
 Implemented v1 scope for issue #714:
 
 - Existing Fugitive/native single-file diff workflow (`vim.wo.diff`). In a native diff, a worktree-local buffer is the new side and its paired external snapshot is the old side.
+- Normal tracked buffers, with committed and current-buffer blob identities kept distinct instead of pretending the buffer is a diff side.
 - Create an anchored contextual thread from the current line/visual range.
-- Require an explicit target Pinet agent for new threads.
+- Assign one Pinet agent as document owner and subscribe additional agents to document activity through the shared broker document domain.
+- Default new threads to the document owner; require an explicit owner only when the document is first introduced.
 - List/open/reply/resolve/reopen threads for the current file.
 - Persist thread state and anchors in Pinet `threads.metadata` and messages in Pinet `messages`.
 - Restore open and resolved signs by querying the broker when Neovim reconnects, enters a diff buffer, or `:PinetThreads` runs.
@@ -37,6 +39,12 @@ Contextual thread commands:
 - `:PinetReply <thread_id> <body>` — add a user reply to an existing thread.
 - `:PinetResolve [thread_id]` — mark a thread resolved.
 - `:PinetReopen [thread_id]` — reopen a resolved thread.
+- `:PinetOwner [agent_id]` — set the current tracked document owner.
+- `:PinetSubscribe [agent_id]` — subscribe an agent to document thread activity.
+- `:PinetUnsubscribe [agent_id]` — remove a document subscription.
+- `:PinetSubscribers` — show the document owner and subscribers.
+
+Document ownership and subscriptions are persisted in BrokerDB and shared across adapters. Slack threads are bound to the same document-domain ports through aliases; transports do not maintain separate ownership tables. Subscriptions grant delivery, not thread-ownership or reply authority.
 
 Default navigation mappings:
 
@@ -47,7 +55,7 @@ Default navigation mappings:
 
 The broker-hosted adapter owns `/tmp/pi-nvim/<sha256(canonicalWorktree + ":" + branch)>.sock`. Both Pi and Neovim canonicalize `git rev-parse --show-toplevel`, so starting Pi in a repository subdirectory does not change the socket identity. Editor context and repo-relative `open_in_editor` paths use that same canonical worktree root rather than Neovim's current directory. The standalone `nvim-bridge` pi extension is a client of this socket for editor-context hydration and `open_in_editor`; it does not start a competing server.
 
-To avoid the target prompt for each new thread, set the Pinet agent id shown by `/pinet status`:
+To avoid the owner/subscriber prompt when first assigning a document, set the Pinet agent id shown by `/pinet status`:
 
 ```lua
 vim.g.pinet_agent_id = "<agent-id>"

--- a/nvim-bridge/nvim-lua.test.ts
+++ b/nvim-bridge/nvim-lua.test.ts
@@ -44,7 +44,7 @@ describe("pi-nvim Lua integration", () => {
             "+runtime plugin/pi-nvim.lua",
             `+lua ${fakeSocket}`,
             "+lua require('pi-nvim').setup()",
-            "+lua for _, name in ipairs({ 'PiCommsOpen', 'PiCommsAdd', 'PiCommsRead', 'PiCommsClean' }) do assert(vim.fn.exists(':' .. name) == 0) end; for _, name in ipairs({ 'PinetComment', 'PinetThreads', 'PinetReply' }) do assert(vim.fn.exists(':' .. name) == 2) end",
+            "+lua for _, name in ipairs({ 'PiCommsOpen', 'PiCommsAdd', 'PiCommsRead', 'PiCommsClean' }) do assert(vim.fn.exists(':' .. name) == 0) end; for _, name in ipairs({ 'PinetComment', 'PinetThreads', 'PinetReply', 'PinetOwner', 'PinetSubscribe', 'PinetUnsubscribe', 'PinetSubscribers' }) do assert(vim.fn.exists(':' .. name) == 2) end",
             "+qa",
           ],
           { encoding: "utf8" },
@@ -93,6 +93,57 @@ describe("pi-nvim Lua integration", () => {
         { cwd: subdir, encoding: "utf8" },
       );
       expect(`${result.stdout}${result.stderr}`).toBe("");
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(!hasNvim())("creates a revision-aware comment from a normal tracked buffer", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "pi-nvim-normal-buffer-"));
+    const appPath = path.join(dir, "src", "app.ts");
+    const scriptPath = path.join(dir, "test.lua");
+    mkdirSync(path.dirname(appPath), { recursive: true });
+    writeFileSync(appPath, "export const value = 1;\n", "utf8");
+    execFileSync("git", ["init", "-q"], { cwd: dir });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir });
+    execFileSync("git", ["config", "user.name", "Test"], { cwd: dir });
+    execFileSync("git", ["add", "src/app.ts"], { cwd: dir });
+    execFileSync("git", ["commit", "-qm", "initial"], { cwd: dir });
+
+    const pluginRoot = path.join(__dirname, "nvim");
+    writeFileSync(
+      scriptPath,
+      [
+        `_G.pinet_create = nil`,
+        `package.loaded['pi-nvim.socket'] = {`,
+        `  request = function(kind, payload)`,
+        `    if kind == 'pinet.document.get' then return { ownerAgentId = 'agent-1', subscribers = {} }, nil end`,
+        `    if kind == 'pinet.thread.create' then _G.pinet_create = payload; return { threadId = 'nvim:test' }, nil end`,
+        `    if kind == 'pinet.thread.list' then return { threads = {} }, nil end`,
+        `    error('unexpected request ' .. kind)`,
+        `  end,`,
+        `  on = function() return function() end end,`,
+        `}`,
+        `vim.cmd('edit ' .. vim.fn.fnameescape(${JSON.stringify(appPath)}))`,
+        `require('pi-nvim.comments').create({ body = 'Normal comment' })`,
+        `assert(_G.pinet_create.targetAgentId == 'agent-1')`,
+        `assert(_G.pinet_create.anchor.anchorKind == 'normal')`,
+        `assert(_G.pinet_create.anchor.path == 'src/app.ts')`,
+        `assert(_G.pinet_create.anchor.dirty == false)`,
+        `assert(_G.pinet_create.anchor.headBlobOid == _G.pinet_create.anchor.blobOid)`,
+        `vim.cmd('qa!')`,
+      ].join("\n"),
+      "utf8",
+    );
+
+    try {
+      const result = spawnSync(
+        "nvim",
+        ["--headless", "--clean", "-n", "--cmd", `set rtp^=${pluginRoot}`, "-l", scriptPath],
+        { cwd: dir, encoding: "utf8" },
+      );
+      expect(`${result.stdout}${result.stderr}`).not.toContain("Error");
       expect(result.status).toBe(0);
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/nvim-bridge/nvim-lua.test.ts
+++ b/nvim-bridge/nvim-lua.test.ts
@@ -44,7 +44,7 @@ describe("pi-nvim Lua integration", () => {
             "+runtime plugin/pi-nvim.lua",
             `+lua ${fakeSocket}`,
             "+lua require('pi-nvim').setup()",
-            "+lua for _, name in ipairs({ 'PiCommsOpen', 'PiCommsAdd', 'PiCommsRead', 'PiCommsClean' }) do assert(vim.fn.exists(':' .. name) == 0) end; for _, name in ipairs({ 'PinetComment', 'PinetThreads', 'PinetReply', 'PinetOwner', 'PinetSubscribe', 'PinetUnsubscribe', 'PinetSubscribers' }) do assert(vim.fn.exists(':' .. name) == 2) end",
+            "+lua for _, name in ipairs({ 'PiCommsOpen', 'PiCommsAdd', 'PiCommsRead', 'PiCommsClean' }) do assert(vim.fn.exists(':' .. name) == 0) end; for _, name in ipairs({ 'PinetComment', 'PinetThreads', 'PinetReply', 'PinetOwner', 'PinetSubscribe', 'PinetUnsubscribe', 'PinetSubscribers', 'PinetBindSlack' }) do assert(vim.fn.exists(':' .. name) == 2) end",
             "+qa",
           ],
           { encoding: "utf8" },

--- a/nvim-bridge/nvim/lua/pi-nvim/comments.lua
+++ b/nvim-bridge/nvim/lua/pi-nvim/comments.lua
@@ -49,7 +49,14 @@ local function current_anchor()
   common_dir = (vim.uv or vim.loop).fs_realpath(common_dir) or common_dir
   local repository = common_dir:match('^(.*)/%.git$') or common_dir
   local file, side = paths.buffer_path_and_side(worktree)
-  if not file or not side then
+  if not file then
+    return nil
+  end
+  local is_diff = vim.wo.diff
+  if is_diff and not side then
+    return nil
+  end
+  if not is_diff and not run_git(worktree, { 'ls-files', '--error-unmatch', '--', file }) then
     return nil
   end
 
@@ -64,6 +71,21 @@ local function current_anchor()
     return nil
   end
 
+  if not is_diff then
+    local head_blob_oid = run_git(worktree, { 'rev-parse', 'HEAD:' .. file })
+    return {
+      repository = repository,
+      worktree = worktree,
+      path = file,
+      baseOid = base_oid or vim.NIL,
+      headOid = head_oid,
+      blobOid = blob_oid,
+      anchorKind = 'normal',
+      headBlobOid = head_blob_oid or vim.NIL,
+      dirty = head_blob_oid ~= blob_oid,
+    }
+  end
+
   return {
     repository = repository,
     worktree = worktree,
@@ -71,6 +93,7 @@ local function current_anchor()
     baseOid = base_oid or vim.NIL,
     headOid = head_oid,
     blobOid = blob_oid,
+    anchorKind = 'diff',
     side = side,
   }
 end
@@ -166,18 +189,16 @@ end
 
 function M.create(opts)
   opts = opts or {}
-  if not vim.wo.diff then
-    vim.notify('Pinet comment requires a Fugitive/native diff window for v1.', vim.log.levels.WARN)
-    return
-  end
   local revision = current_anchor()
   if not revision then
-    vim.notify('Pinet could not identify this diff side and revision.', vim.log.levels.WARN)
+    vim.notify('Pinet could not identify a tracked file revision.', vim.log.levels.WARN)
     return
   end
-  local target = opts.target_agent_id
-    or vim.g.pinet_agent_id
-    or prompt_text('Target Pinet agent id: ')
+  local document = socket.request('pinet.document.get', { anchor = revision }) or {}
+  local target = opts.target_agent_id or document.ownerAgentId or vim.g.pinet_agent_id
+  if not target and not document.ownerAgentId then
+    target = prompt_text('Document owner Pinet agent id: ')
+  end
   if not target then
     return
   end
@@ -185,7 +206,10 @@ function M.create(opts)
   if not body then
     return
   end
-  local start_line, end_line = get_visual_range_or_cursor()
+  local start_line, end_line = opts.start_line, opts.end_line
+  if not start_line or not end_line then
+    start_line, end_line = get_visual_range_or_cursor()
+  end
   local selected = get_lines_text(start_line, end_line)
   local result, err = socket.request('pinet.thread.create', {
     targetAgentId = target,
@@ -202,6 +226,69 @@ function M.create(opts)
   end
   vim.notify('Pinet thread created: ' .. result.threadId, vim.log.levels.INFO)
   refresh()
+end
+
+function M.document_owner(agent_id)
+  local revision = current_anchor()
+  agent_id = agent_id or prompt_text('Document owner Pinet agent id: ')
+  if not revision or not agent_id then
+    return
+  end
+  local result, err =
+    socket.request('pinet.document.owner', { anchor = revision, agentId = agent_id })
+  if err then
+    vim.notify(
+      'Pinet document owner failed: ' .. (err.message or 'request failed'),
+      vim.log.levels.ERROR
+    )
+    return
+  end
+  vim.notify('Pinet document owner: ' .. tostring(result.ownerAgentId), vim.log.levels.INFO)
+end
+
+function M.document_subscribe(agent_id, subscribe)
+  local revision = current_anchor()
+  agent_id = agent_id or vim.g.pinet_agent_id or prompt_text('Subscriber Pinet agent id: ')
+  if not revision or not agent_id then
+    return
+  end
+  local request = subscribe == false and 'pinet.document.unsubscribe' or 'pinet.document.subscribe'
+  local result, err = socket.request(request, { anchor = revision, agentId = agent_id })
+  if err then
+    vim.notify(
+      'Pinet document subscription failed: ' .. (err.message or 'request failed'),
+      vim.log.levels.ERROR
+    )
+    return
+  end
+  vim.notify(
+    'Pinet subscribers: ' .. table.concat(result.subscribers or {}, ', '),
+    vim.log.levels.INFO
+  )
+end
+
+function M.document_status()
+  local revision = current_anchor()
+  if not revision then
+    vim.notify('Pinet could not identify a tracked file revision.', vim.log.levels.WARN)
+    return
+  end
+  local result, err = socket.request('pinet.document.get', { anchor = revision })
+  if err then
+    vim.notify(
+      'Pinet document status failed: ' .. (err.message or 'request failed'),
+      vim.log.levels.ERROR
+    )
+    return
+  end
+  vim.notify(
+    string.format(
+      'Pinet document owner=%s subscribers=%s',
+      tostring(result.ownerAgentId or 'none'),
+      table.concat(result.subscribers or {}, ', ')
+    ),
+    vim.log.levels.INFO
+  )
 end
 
 function M.reply(thread_id, body)

--- a/nvim-bridge/nvim/lua/pi-nvim/comments.lua
+++ b/nvim-bridge/nvim/lua/pi-nvim/comments.lua
@@ -291,6 +291,24 @@ function M.document_status()
   )
 end
 
+function M.document_bind_thread(thread_id)
+  local revision = current_anchor()
+  thread_id = thread_id or prompt_text('Slack thread id: ')
+  if not revision or not thread_id then
+    return
+  end
+  local result, err =
+    socket.request('pinet.document.bind_thread', { anchor = revision, threadId = thread_id })
+  if err then
+    vim.notify(
+      'Pinet document binding failed: ' .. (err.message or 'request failed'),
+      vim.log.levels.ERROR
+    )
+    return
+  end
+  vim.notify('Pinet document bound: ' .. tostring(result.documentId), vim.log.levels.INFO)
+end
+
 function M.reply(thread_id, body)
   thread_id = thread_id or prompt_text('Thread id: ')
   body = body or prompt_text('Reply: ')

--- a/nvim-bridge/nvim/lua/pi-nvim/init.lua
+++ b/nvim-bridge/nvim/lua/pi-nvim/init.lua
@@ -20,7 +20,7 @@ function M.setup(_opts)
         return
       end
       events.on_buf_enter()
-      if vim.wo.diff and socket.is_connected() then
+      if socket.is_connected() then
         comments.refresh({ include_resolved = true })
       end
     end,
@@ -63,9 +63,7 @@ function M.setup(_opts)
   socket.on('connected', function()
     events.on_buf_enter()
     events.on_win_scrolled()
-    if vim.wo.diff then
-      comments.refresh({ include_resolved = true })
-    end
+    comments.refresh({ include_resolved = true })
   end)
 
   -- Seed initial context, useful when plugin itself is lazy-loaded.

--- a/nvim-bridge/nvim/plugin/pi-nvim.lua
+++ b/nvim-bridge/nvim/plugin/pi-nvim.lua
@@ -71,6 +71,10 @@ vim.api.nvim_create_user_command('PinetSubscribers', function()
   require('pi-nvim.comments').document_status()
 end, { desc = 'Show current document owner and subscribers' })
 
+vim.api.nvim_create_user_command('PinetBindSlack', function(opts)
+  require('pi-nvim.comments').document_bind_thread(opts.args)
+end, { desc = 'Bind a Slack thread to the current document', nargs = 1 })
+
 vim.keymap.set('n', ']p', function()
   require('pi-nvim.comments').next()
 end, { desc = 'Next Pinet contextual thread' })

--- a/nvim-bridge/nvim/plugin/pi-nvim.lua
+++ b/nvim-bridge/nvim/plugin/pi-nvim.lua
@@ -24,8 +24,16 @@ vim.api.nvim_create_user_command('PiNvimStatus', function()
 end, { desc = 'Show pi-nvim bridge status' })
 
 vim.api.nvim_create_user_command('PinetComment', function(opts)
-  require('pi-nvim.comments').create({ body = opts.args ~= '' and opts.args or nil })
-end, { desc = 'Create a Pinet contextual thread on the current diff line/range', nargs = '*' })
+  require('pi-nvim.comments').create({
+    body = opts.args ~= '' and opts.args or nil,
+    start_line = opts.range > 0 and opts.line1 or nil,
+    end_line = opts.range > 0 and opts.line2 or nil,
+  })
+end, {
+  desc = 'Create a Pinet contextual thread on the current file line/range',
+  nargs = '*',
+  range = true,
+})
 
 vim.api.nvim_create_user_command('PinetThreads', function()
   require('pi-nvim.comments').refresh({ include_resolved = true })
@@ -46,6 +54,22 @@ end, { desc = 'Reopen a Pinet contextual thread', nargs = '?' })
 vim.api.nvim_create_user_command('PinetThreadOpen', function(opts)
   require('pi-nvim.comments').open_thread(opts.args ~= '' and opts.args or nil)
 end, { desc = 'Open a Pinet contextual thread pane', nargs = '?' })
+
+vim.api.nvim_create_user_command('PinetOwner', function(opts)
+  require('pi-nvim.comments').document_owner(opts.args ~= '' and opts.args or nil)
+end, { desc = 'Set the current document Pinet owner', nargs = '?' })
+
+vim.api.nvim_create_user_command('PinetSubscribe', function(opts)
+  require('pi-nvim.comments').document_subscribe(opts.args ~= '' and opts.args or nil, true)
+end, { desc = 'Subscribe an agent to the current document', nargs = '?' })
+
+vim.api.nvim_create_user_command('PinetUnsubscribe', function(opts)
+  require('pi-nvim.comments').document_subscribe(opts.args ~= '' and opts.args or nil, false)
+end, { desc = 'Unsubscribe an agent from the current document', nargs = '?' })
+
+vim.api.nvim_create_user_command('PinetSubscribers', function()
+  require('pi-nvim.comments').document_status()
+end, { desc = 'Show current document owner and subscribers' })
 
 vim.keymap.set('n', ']p', function()
   require('pi-nvim.comments').next()

--- a/plans/nvim-pi-sync.md
+++ b/plans/nvim-pi-sync.md
@@ -158,6 +158,7 @@ The contextual-thread adapter also supports ordinary tracked buffers through a s
 - `document_aliases` binds native identities such as a canonical Git worktree file or Slack thread to that document.
 - `document_subscriptions` stores additional agent recipients. Subscriptions grant delivery, not ownership or reply authority.
 - Neovim Git-file document identity hashes canonical `repository`, `worktree`, and repo-relative `path`; Slack thread identity hashes its scope, channel, and thread timestamp.
+- Both runtime paths resolve existing aliases before minting a document id. `:PinetBindSlack <thread_id>` provides the explicit cross-adapter rebind when a Slack conversation corresponds to a tracked file; subsequent Slack ingress reuses that canonical Git document.
 - Contextual threads retain their existing `threads`/`messages` lifecycle and reference the shared `documentId`. The router fans document events out once to the unique owner/subscriber set.
 - Agent replies continue through the generic transport send path; document subscribers receive those persisted replies without changing the thread owner.
 - Diff anchors remain schema v1. Normal-buffer anchors use schema v2 with `anchorKind: "normal"`, current `headOid`, optional committed `headBlobOid`, current in-memory `blobOid`, and `dirty`. They never claim an old/new diff side.

--- a/plans/nvim-pi-sync.md
+++ b/plans/nvim-pi-sync.md
@@ -149,3 +149,16 @@ The active replacement is intentionally small and Pinet-native:
 - Relevant unresolved threads are revision-filtered and injected into later agent runs with bounded message history; resolved threads remain durable but are omitted.
 - Agents reply with the generic Pinet dispatcher `reply` action against an existing thread id; no review-specific tool or table exists.
 - v1 supports one current Fugitive/native diff file. GitHub sync, multi-file review UI, and anchor relocation remain deferred; changed revisions are omitted rather than guessed.
+
+## Issue #1022: normal documents, ownership, and subscriptions
+
+The contextual-thread adapter also supports ordinary tracked buffers through a shared broker document domain:
+
+- `documents` stores one durable owner and transport-neutral metadata.
+- `document_aliases` binds native identities such as a canonical Git worktree file or Slack thread to that document.
+- `document_subscriptions` stores additional agent recipients. Subscriptions grant delivery, not ownership or reply authority.
+- Neovim Git-file document identity hashes canonical `repository`, `worktree`, and repo-relative `path`; Slack thread identity hashes its scope, channel, and thread timestamp.
+- Contextual threads retain their existing `threads`/`messages` lifecycle and reference the shared `documentId`. The router fans document events out once to the unique owner/subscriber set.
+- Agent replies continue through the generic transport send path; document subscribers receive those persisted replies without changing the thread owner.
+- Diff anchors remain schema v1. Normal-buffer anchors use schema v2 with `anchorKind: "normal"`, current `headOid`, optional committed `headBlobOid`, current in-memory `blobOid`, and `dirty`. They never claim an old/new diff side.
+- Normal-buffer restoration remains exact: a changed or unsaved buffer blob does not inherit signs from a different content identity.

--- a/slack-bridge/broker/message-send.test.ts
+++ b/slack-bridge/broker/message-send.test.ts
@@ -5,9 +5,15 @@ import type { BrokerMessage, ThreadInfo } from "./types.js";
 function createFakeDb() {
   const threads = new Map<string, ThreadInfo>();
   let nextMessageId = 1;
+  const documentRecipients = new Map<string, string[]>();
 
   return {
     threads,
+    documentRecipients,
+    lastTargetAgentIds: [] as string[],
+    getDocumentRecipients(documentId: string) {
+      return documentRecipients.get(documentId) ?? [];
+    },
     getThread(threadId: string) {
       return threads.get(threadId) ?? null;
     },
@@ -59,9 +65,10 @@ function createFakeDb() {
       direction: "inbound" | "outbound",
       sender: string,
       body: string,
-      _targetAgentIds: string[],
+      targetAgentIds: string[],
       metadata?: Record<string, unknown>,
     ): BrokerMessage {
+      this.lastTargetAgentIds = targetAgentIds;
       return {
         id: nextMessageId++,
         threadId,
@@ -252,6 +259,26 @@ describe("sendBrokerMessage", () => {
       ownerAgent: "agent-1",
     });
     expect(result.thread).toMatchObject({ ownerAgent: "agent-1", channel: "C-NEW" });
+  });
+
+  it("fans document-backed replies out to subscribers without echoing to the sender", async () => {
+    const db = createFakeDb();
+    const send = vi.fn(async () => undefined);
+    db.createThread("nvim:1", "nvim", "repo", "owner");
+    db.updateThread("nvim:1", { metadata: { documentId: "doc:1" } });
+    db.documentRecipients.set("doc:1", ["owner", "subscriber", "subscriber"]);
+
+    const result = await sendBrokerMessage(
+      { db, adapters: [{ name: "nvim", send }] },
+      {
+        threadId: "nvim:1",
+        body: "Reviewed",
+        senderAgentId: "owner",
+      },
+    );
+
+    expect(db.lastTargetAgentIds).toEqual(["subscriber"]);
+    expect(result.message.metadata).toMatchObject({ documentId: "doc:1" });
   });
 
   it("does not steal or send to an existing transport thread owned by another agent", async () => {

--- a/slack-bridge/broker/router.test.ts
+++ b/slack-bridge/broker/router.test.ts
@@ -271,7 +271,12 @@ describe("MessageRouter — route", () => {
 
   it("broadcasts document activity to its owner and subscribers without duplicates", () => {
     db.agents = [
-      makeAgent({ id: "owner", name: "Owner" }),
+      makeAgent({
+        id: "owner",
+        name: "Owner",
+        disconnectedAt: "2026-01-01T00:00:00Z",
+        resumableUntil: "2099-01-01T00:00:00Z",
+      }),
       makeAgent({ id: "subscriber", name: "Subscriber" }),
     ];
     db.documentRecipients.set("doc:1", ["owner", "subscriber", "owner"]);

--- a/slack-bridge/broker/router.test.ts
+++ b/slack-bridge/broker/router.test.ts
@@ -21,9 +21,14 @@ class StubBrokerDBInterface implements BrokerDBInterface {
   channelAssignments = new Map<string, ChannelAssignment>();
   allowedUsers: Set<string> | null = null;
   inbox: Array<{ agentId: string; message: InboundMessage }> = [];
+  documentRecipients = new Map<string, string[]>();
 
   getThread(threadId: string): ThreadInfo | null {
     return this.threads.get(threadId) ?? null;
+  }
+
+  getDocumentRecipients(documentId: string): string[] {
+    return this.documentRecipients.get(documentId) ?? [];
   }
 
   getAgentById(agentId: string): AgentInfo | null {
@@ -262,6 +267,20 @@ describe("MessageRouter — route", () => {
   beforeEach(() => {
     db = new StubBrokerDBInterface();
     router = new MessageRouter(db);
+  });
+
+  it("broadcasts document activity to its owner and subscribers without duplicates", () => {
+    db.agents = [
+      makeAgent({ id: "owner", name: "Owner" }),
+      makeAgent({ id: "subscriber", name: "Subscriber" }),
+    ];
+    db.documentRecipients.set("doc:1", ["owner", "subscriber", "owner"]);
+    db.threads.set("t-100", makeThread({ threadId: "t-100", metadata: { documentId: "doc:1" } }));
+
+    expect(router.route(makeMessage())).toEqual({
+      action: "broadcast",
+      agentIds: ["owner", "subscriber"],
+    });
   });
 
   it("routes to thread owner when thread has an owner", () => {

--- a/slack-bridge/code-anchor.test.ts
+++ b/slack-bridge/code-anchor.test.ts
@@ -35,6 +35,31 @@ describe("contextual thread metadata", () => {
     ).toBe(false);
   });
 
+  it("builds a normal-buffer anchor without pretending it is a diff side", () => {
+    const metadata = buildContextualThreadMetadata({
+      repository: "/repo",
+      worktree: "/repo",
+      path: "README.md",
+      headOid: "head",
+      blobOid: "dirty-buffer",
+      anchorKind: "normal",
+      headBlobOid: "committed-blob",
+      dirty: true,
+      startLine: 3,
+    });
+
+    expect(metadata.schemaVersion).toBe(2);
+    expect(metadata.codeAnchor).toMatchObject({
+      anchorKind: "normal",
+      headBlobOid: "committed-blob",
+      blobOid: "dirty-buffer",
+      dirty: true,
+    });
+    expect(metadata.codeAnchor).not.toHaveProperty("side");
+    expect(parseContextualThreadMetadata(metadata as ContextJsonValue)).toEqual(metadata);
+    expect(formatAnchorForMessage(metadata)).toContain("mode=normal dirty=true");
+  });
+
   it("stores resolution state in ordinary thread metadata", () => {
     const metadata = buildContextualThreadMetadata({
       repository: "/repo",

--- a/slack-bridge/code-anchor.test.ts
+++ b/slack-bridge/code-anchor.test.ts
@@ -35,6 +35,33 @@ describe("contextual thread metadata", () => {
     ).toBe(false);
   });
 
+  it("parses stored schema-v1 diff anchors without an anchorKind field", () => {
+    const stored: ContextJsonValue = {
+      pinetKind: "contextual_thread",
+      schemaVersion: 1,
+      codeAnchor: {
+        repository: "/repo",
+        worktree: "/repo",
+        path: "src/legacy.ts",
+        baseOid: null,
+        headOid: "head",
+        blobOid: "blob",
+        side: "old",
+        startLine: 4,
+        endLine: 4,
+        selectedTextSha256: null,
+        contextSha256: null,
+      },
+      state: { resolved: false },
+    };
+
+    expect(parseContextualThreadMetadata(stored)?.codeAnchor).toMatchObject({
+      anchorKind: "diff",
+      side: "old",
+      path: "src/legacy.ts",
+    });
+  });
+
   it("builds a normal-buffer anchor without pretending it is a diff side", () => {
     const metadata = buildContextualThreadMetadata({
       repository: "/repo",

--- a/slack-bridge/code-anchor.ts
+++ b/slack-bridge/code-anchor.ts
@@ -12,6 +12,7 @@ export interface ContextJsonObject {
 }
 
 export type CodeAnchorSide = "old" | "new";
+export type CodeAnchorKind = "diff" | "normal";
 
 export interface CodeRevisionIdentity extends ContextJsonObject {
   repository: string;
@@ -20,7 +21,10 @@ export interface CodeRevisionIdentity extends ContextJsonObject {
   baseOid: string | null;
   headOid: string;
   blobOid: string;
-  side: CodeAnchorSide;
+  anchorKind: CodeAnchorKind;
+  side?: CodeAnchorSide;
+  headBlobOid?: string | null;
+  dirty?: boolean;
 }
 
 export interface CodeAnchor extends CodeRevisionIdentity {
@@ -38,7 +42,7 @@ export interface ContextualThreadState extends ContextJsonObject {
 
 export interface ContextualThreadMetadata extends ContextJsonObject {
   pinetKind: "contextual_thread";
-  schemaVersion: 1;
+  schemaVersion: 1 | 2;
   codeAnchor: CodeAnchor;
   state: ContextualThreadState;
 }
@@ -58,7 +62,10 @@ export function buildContextualThreadMetadata(input: {
   baseOid?: string | null;
   headOid: string;
   blobOid: string;
-  side: CodeAnchorSide;
+  anchorKind?: CodeAnchorKind;
+  side?: CodeAnchorSide;
+  headBlobOid?: string | null;
+  dirty?: boolean;
   startLine: number;
   endLine?: number;
   selectedText?: string | null;
@@ -66,9 +73,11 @@ export function buildContextualThreadMetadata(input: {
 }): ContextualThreadMetadata {
   const startLine = Math.max(1, Math.floor(input.startLine));
   const endLine = Math.max(startLine, Math.floor(input.endLine ?? startLine));
+  const anchorKind = input.anchorKind ?? "diff";
+  if (anchorKind === "diff" && !input.side) throw new Error("diff code anchor side is required");
   return {
     pinetKind: "contextual_thread",
-    schemaVersion: 1,
+    schemaVersion: anchorKind === "normal" ? 2 : 1,
     codeAnchor: {
       repository: input.repository,
       worktree: input.worktree,
@@ -76,7 +85,11 @@ export function buildContextualThreadMetadata(input: {
       baseOid: input.baseOid ?? null,
       headOid: input.headOid,
       blobOid: input.blobOid,
-      side: input.side,
+      anchorKind,
+      ...(input.side ? { side: input.side } : {}),
+      ...(anchorKind === "normal"
+        ? { headBlobOid: input.headBlobOid ?? null, dirty: input.dirty === true }
+        : {}),
       startLine,
       endLine,
       selectedTextSha256: input.selectedText ? sha256Text(input.selectedText) : null,
@@ -106,7 +119,11 @@ export function parseContextualThreadMetadata(
   value: ContextJsonValue | undefined,
 ): ContextualThreadMetadata | null {
   const metadata = readRecord(value);
-  if (!metadata || metadata.pinetKind !== "contextual_thread" || metadata.schemaVersion !== 1) {
+  if (
+    !metadata ||
+    metadata.pinetKind !== "contextual_thread" ||
+    (metadata.schemaVersion !== 1 && metadata.schemaVersion !== 2)
+  ) {
     return null;
   }
 
@@ -119,8 +136,12 @@ export function parseContextualThreadMetadata(
   const path = readString(anchorRecord, "path");
   const headOid = readString(anchorRecord, "headOid");
   const blobOid = readString(anchorRecord, "blobOid");
+  const anchorKind = metadata.schemaVersion === 2 ? anchorRecord.anchorKind : "diff";
+  if (anchorKind !== "diff" && anchorKind !== "normal") return null;
   const side =
     anchorRecord.side === "old" || anchorRecord.side === "new" ? anchorRecord.side : null;
+  if (anchorKind === "diff" && !side) return null;
+  if (anchorKind === "normal" && typeof anchorRecord.dirty !== "boolean") return null;
   const startLine = readPositiveInteger(anchorRecord, "startLine");
   const endLine = readPositiveInteger(anchorRecord, "endLine");
   if (
@@ -129,7 +150,6 @@ export function parseContextualThreadMetadata(
     !path ||
     !headOid ||
     !blobOid ||
-    !side ||
     startLine == null ||
     endLine == null
   ) {
@@ -140,7 +160,7 @@ export function parseContextualThreadMetadata(
   const resolvedBy = readString(stateRecord, "resolvedBy");
   return {
     pinetKind: "contextual_thread",
-    schemaVersion: 1,
+    schemaVersion: metadata.schemaVersion,
     codeAnchor: {
       repository,
       worktree,
@@ -148,7 +168,14 @@ export function parseContextualThreadMetadata(
       baseOid: readString(anchorRecord, "baseOid"),
       headOid,
       blobOid,
-      side,
+      anchorKind,
+      ...(side ? { side } : {}),
+      ...(anchorKind === "normal"
+        ? {
+            headBlobOid: readString(anchorRecord, "headBlobOid"),
+            dirty: anchorRecord.dirty === true,
+          }
+        : {}),
       startLine,
       endLine,
       selectedTextSha256: readString(anchorRecord, "selectedTextSha256"),
@@ -182,7 +209,10 @@ export function hasSameCodeRevision(anchor: CodeAnchor, candidate: CodeRevisionI
     anchor.baseOid === candidate.baseOid &&
     anchor.headOid === candidate.headOid &&
     anchor.blobOid === candidate.blobOid &&
-    anchor.side === candidate.side
+    anchor.anchorKind === candidate.anchorKind &&
+    anchor.side === candidate.side &&
+    anchor.headBlobOid === candidate.headBlobOid &&
+    anchor.dirty === candidate.dirty
   );
 }
 
@@ -193,5 +223,7 @@ export function formatAnchorForMessage(metadata: ContextualThreadMetadata): stri
       ? `${anchor.path}:${anchor.startLine}`
       : `${anchor.path}:${anchor.startLine}-${anchor.endLine}`;
   const base = anchor.baseOid ? ` base=${anchor.baseOid}` : "";
-  return `[code-anchor ${range} side=${anchor.side} head=${anchor.headOid} blob=${anchor.blobOid}${base}]`;
+  const mode =
+    anchor.anchorKind === "diff" ? `side=${anchor.side}` : `mode=normal dirty=${anchor.dirty}`;
+  return `[code-anchor ${range} ${mode} head=${anchor.headOid} blob=${anchor.blobOid}${base}]`;
 }

--- a/slack-bridge/index.ts
+++ b/slack-bridge/index.ts
@@ -812,7 +812,21 @@ export default function (pi: ExtensionAPI) {
           return;
         }
 
-        if (decision.action === "deliver" || decision.action === "unrouted") {
+        if (decision.action === "broadcast") {
+          const remoteAgentIds = decision.agentIds.filter((agentId) => agentId !== selfId);
+          if (broker.db.queueMessageToAgents) {
+            broker.db.queueMessageToAgents(remoteAgentIds, routedMessage);
+          } else {
+            for (const agentId of remoteAgentIds) broker.db.queueMessage(agentId, routedMessage);
+          }
+          if (!decision.agentIds.includes(selfId)) return;
+        }
+
+        if (
+          decision.action === "deliver" ||
+          decision.action === "broadcast" ||
+          decision.action === "unrouted"
+        ) {
           const persisted = routedMessage.threadId
             ? persistDeliveredInboundMessage(broker.db, selfId, routedMessage)
             : null;

--- a/slack-bridge/nvim-pinet-adapter.test.ts
+++ b/slack-bridge/nvim-pinet-adapter.test.ts
@@ -232,6 +232,12 @@ describe("NvimPinetAdapter", () => {
           },
         ],
       });
+      await request(socketPath, "pinet.document.owner", {
+        anchor: normalAnchor,
+        agentId: "agent-2",
+      });
+      expect(db.getThread(normalCreated.threadId as string)?.ownerAgent).toBe("agent-2");
+      expect(db.getThread(threadId)?.ownerAgent).toBe("agent-2");
 
       await request(socketPath, "pinet.thread.reply", { threadId, body: "Follow-up" });
       expect(inboundBodies).toContain("Follow-up");

--- a/slack-bridge/nvim-pinet-adapter.test.ts
+++ b/slack-bridge/nvim-pinet-adapter.test.ts
@@ -12,7 +12,7 @@ import {
   type NvimAdapterDbPort,
 } from "./nvim-pinet-adapter.js";
 import { BrokerDB } from "./broker/schema.js";
-import type { BrokerMessage, ThreadInfo } from "./broker/types.js";
+import type { BrokerMessage, DocumentInfo, ThreadInfo } from "./broker/types.js";
 
 function request(
   socketPath: string,
@@ -45,9 +45,43 @@ function request(
 
 function createDb(): NvimAdapterDbPort {
   const threads = new Map<string, ThreadInfo>();
+  const documents = new Map<string, DocumentInfo>();
+  const subscribers = new Map<string, Set<string>>();
   const messages: BrokerMessage[] = [];
   return {
     getThread: (threadId) => threads.get(threadId) ?? null,
+    getDocument: (documentId) => documents.get(documentId) ?? null,
+    upsertDocument: (document) => {
+      const now = new Date().toISOString();
+      const existing = documents.get(document.documentId);
+      const stored = { ...document, createdAt: existing?.createdAt ?? now, updatedAt: now };
+      documents.set(document.documentId, stored);
+      return stored;
+    },
+    bindDocumentAlias: () => ({}),
+    setDocumentOwner: (documentId, ownerAgent) => {
+      const existing = documents.get(documentId);
+      if (!existing) throw new Error(`Unknown document ${documentId}`);
+      const updated = { ...existing, ownerAgent, ownerBinding: "explicit" as const };
+      documents.set(documentId, updated);
+      return updated;
+    },
+    subscribeDocument: (documentId, agentId) => {
+      const values = subscribers.get(documentId) ?? new Set<string>();
+      values.add(agentId);
+      subscribers.set(documentId, values);
+    },
+    unsubscribeDocument: (documentId, agentId) => subscribers.get(documentId)?.delete(agentId),
+    listDocumentSubscribers: (documentId) => [...(subscribers.get(documentId) ?? [])].sort(),
+    getDocumentRecipients: (documentId) => {
+      const document = documents.get(documentId);
+      return [
+        ...new Set([
+          ...(document?.ownerAgent ? [document.ownerAgent] : []),
+          ...(subscribers.get(documentId) ?? []),
+        ]),
+      ];
+    },
     createThread: (thread) => {
       threads.set(thread.threadId, thread);
       return thread;
@@ -108,7 +142,10 @@ describe("NvimPinetAdapter", () => {
       headOid,
       baseOid: null,
       db,
-      getAgentById: (agentId) => (agentId === "agent-1" ? { id: agentId, name: "Agent" } : null),
+      getAgentById: (agentId) =>
+        agentId === "agent-1" || agentId === "agent-2"
+          ? { id: agentId, name: `Agent ${agentId}` }
+          : null,
     });
     const inboundBodies: string[] = [];
     adapter.onInbound((message) => inboundBodies.push(message.text));
@@ -144,6 +181,7 @@ describe("NvimPinetAdapter", () => {
         baseOid: null,
         headOid,
         blobOid,
+        anchorKind: "diff",
         side: "new",
       };
       const created = await request(socketPath, "pinet.thread.create", {
@@ -156,6 +194,44 @@ describe("NvimPinetAdapter", () => {
       const threadId = created.threadId as string;
       expect(threadId).toMatch(/^nvim:/);
       expect(inboundBodies[0]).toContain(`[code-anchor app.ts:1 side=new head=${headOid}`);
+
+      const normalAnchor = {
+        repository: repoRoot,
+        worktree: repoRoot,
+        path: "app.ts",
+        baseOid: null,
+        headOid,
+        blobOid,
+        anchorKind: "normal",
+        headBlobOid: blobOid,
+        dirty: false,
+      };
+      await expect(
+        request(socketPath, "pinet.document.subscribe", {
+          anchor: normalAnchor,
+          agentId: "agent-2",
+        }),
+      ).resolves.toMatchObject({ ownerAgentId: "agent-1", subscribers: ["agent-2"] });
+      const normalCreated = await request(socketPath, "pinet.thread.create", {
+        body: "Normal buffer comment",
+        anchor: normalAnchor,
+        startLine: 1,
+        endLine: 1,
+      });
+      expect(normalCreated.threadId).toMatch(/^nvim:/);
+      await expect(
+        request(socketPath, "pinet.thread.list", { anchor: normalAnchor }),
+      ).resolves.toMatchObject({
+        threads: [
+          {
+            threadId: normalCreated.threadId,
+            metadata: {
+              schemaVersion: 2,
+              codeAnchor: { anchorKind: "normal", dirty: false, headBlobOid: blobOid },
+            },
+          },
+        ],
+      });
 
       await request(socketPath, "pinet.thread.reply", { threadId, body: "Follow-up" });
       expect(inboundBodies).toContain("Follow-up");
@@ -207,6 +283,7 @@ describe("NvimPinetAdapter", () => {
       baseOid: null,
       headOid,
       blobOid,
+      anchorKind: "diff",
       side: "new",
     };
     const socketPath =

--- a/slack-bridge/nvim-pinet-adapter.test.ts
+++ b/slack-bridge/nvim-pinet-adapter.test.ts
@@ -46,11 +46,16 @@ function request(
 function createDb(): NvimAdapterDbPort {
   const threads = new Map<string, ThreadInfo>();
   const documents = new Map<string, DocumentInfo>();
+  const aliases = new Map<string, string>();
   const subscribers = new Map<string, Set<string>>();
   const messages: BrokerMessage[] = [];
   return {
     getThread: (threadId) => threads.get(threadId) ?? null,
     getDocument: (documentId) => documents.get(documentId) ?? null,
+    getDocumentByAlias: (source, externalId) => {
+      const documentId = aliases.get(`${source}\0${externalId}`);
+      return documentId ? (documents.get(documentId) ?? null) : null;
+    },
     upsertDocument: (document) => {
       const now = new Date().toISOString();
       const existing = documents.get(document.documentId);
@@ -58,7 +63,9 @@ function createDb(): NvimAdapterDbPort {
       documents.set(document.documentId, stored);
       return stored;
     },
-    bindDocumentAlias: () => ({}),
+    bindDocumentAlias: (source, externalId, documentId) => {
+      aliases.set(`${source}\0${externalId}`, documentId);
+    },
     setDocumentOwner: (documentId, ownerAgent) => {
       const existing = documents.get(documentId);
       if (!existing) throw new Error(`Unknown document ${documentId}`);
@@ -238,6 +245,36 @@ describe("NvimPinetAdapter", () => {
       });
       expect(db.getThread(normalCreated.threadId as string)?.ownerAgent).toBe("agent-2");
       expect(db.getThread(threadId)?.ownerAgent).toBe("agent-2");
+
+      db.upsertDocument({
+        documentId: "doc:slack-thread:old",
+        kind: "slack_thread",
+        title: "Slack C123/111.222",
+        ownerAgent: "agent-1",
+        ownerBinding: "explicit",
+        metadata: null,
+      });
+      db.subscribeDocument("doc:slack-thread:old", "agent-1");
+      db.createThread({
+        threadId: "111.222",
+        source: "slack",
+        channel: "C123",
+        ownerAgent: "agent-1",
+        ownerBinding: "explicit",
+        metadata: {
+          documentId: "doc:slack-thread:old",
+          documentAliasExternalId: "workspace\\0C123\\0111.222",
+        },
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      const bound = await request(socketPath, "pinet.document.bind_thread", {
+        anchor: normalAnchor,
+        threadId: "111.222",
+      });
+      expect(db.getThread("111.222")?.metadata?.documentId).toBe(bound.documentId);
+      expect(db.getThread("111.222")?.ownerAgent).toBe("agent-2");
+      expect(bound.subscribers).toEqual(["agent-1", "agent-2"]);
 
       await request(socketPath, "pinet.thread.reply", { threadId, body: "Follow-up" });
       expect(inboundBodies).toContain("Follow-up");

--- a/slack-bridge/nvim-pinet-adapter.ts
+++ b/slack-bridge/nvim-pinet-adapter.ts
@@ -21,10 +21,24 @@ import type {
   MessageAdapter,
   OutboundMessage,
   ThreadInfo,
+  DocumentInfo,
 } from "./broker/types.js";
 
 export interface NvimAdapterDbPort {
   getThread(threadId: string): ThreadInfo | null;
+  getDocument(documentId: string): DocumentInfo | null;
+  upsertDocument(document: Omit<DocumentInfo, "createdAt" | "updatedAt">): DocumentInfo;
+  bindDocumentAlias(
+    source: string,
+    externalId: string,
+    documentId: string,
+    metadata?: Record<string, ContextJsonValue> | null,
+  ): void;
+  setDocumentOwner(documentId: string, ownerAgent: string | null): DocumentInfo;
+  subscribeDocument(documentId: string, agentId: string): void;
+  unsubscribeDocument(documentId: string, agentId: string): void;
+  listDocumentSubscribers(documentId: string): string[];
+  getDocumentRecipients(documentId: string): string[];
   createThread(thread: ThreadInfo): ThreadInfo;
   updateThread(threadId: string, updates: Partial<ThreadInfo>): void;
   getThreads(ownerAgent?: string): ThreadInfo[];
@@ -61,7 +75,7 @@ interface NvimRpcRequest {
 }
 
 interface NvimCreateThreadRequest {
-  targetAgentId: string;
+  targetAgentId: string | null;
   body: string;
   anchor: CodeRevisionIdentity;
   startLine: number;
@@ -84,6 +98,15 @@ interface NvimListRequest {
   anchor: CodeRevisionIdentity;
   includeResolved: boolean;
   limit: number;
+}
+
+interface NvimDocumentAgentRequest {
+  anchor: CodeRevisionIdentity;
+  agentId: string;
+}
+
+interface NvimDocumentRequest {
+  anchor: CodeRevisionIdentity;
 }
 
 interface NvimEditorState {
@@ -122,6 +145,13 @@ export function resolveNvimRepositoryContext(cwd: string): NvimRepositoryContext
   } catch {
     return null;
   }
+}
+
+export function buildGitFileDocumentId(
+  anchor: Pick<CodeRevisionIdentity, "repository" | "worktree" | "path">,
+): string {
+  const identity = `${anchor.repository}\0${anchor.worktree}\0${anchor.path}`;
+  return `doc:git-file:${createHash("sha256").update(identity).digest("hex")}`;
 }
 
 function computeRepoSocketHash(worktree: string, branch: string): string {
@@ -181,7 +211,15 @@ function parseAnchor(payload: ContextJsonObject): NvimListRequest["anchor"] | nu
   const headOid = getString(anchor, "headOid");
   const blobOid = getString(anchor, "blobOid");
   const side = anchor.side === "old" || anchor.side === "new" ? anchor.side : null;
-  if (!repository || !worktree || !anchorPath || !headOid || !blobOid || !side) return null;
+  const anchorKind =
+    anchor.anchorKind === "normal" || anchor.anchorKind === "diff"
+      ? anchor.anchorKind
+      : side
+        ? "diff"
+        : null;
+  if (!repository || !worktree || !anchorPath || !headOid || !blobOid || !anchorKind) return null;
+  if (anchorKind === "diff" && !side) return null;
+  if (anchorKind === "normal" && typeof anchor.dirty !== "boolean") return null;
   return {
     repository,
     worktree,
@@ -189,7 +227,11 @@ function parseAnchor(payload: ContextJsonObject): NvimListRequest["anchor"] | nu
     baseOid: getString(anchor, "baseOid"),
     headOid,
     blobOid,
-    side,
+    anchorKind,
+    ...(side ? { side } : {}),
+    ...(anchorKind === "normal"
+      ? { headBlobOid: getString(anchor, "headBlobOid"), dirty: anchor.dirty === true }
+      : {}),
   };
 }
 
@@ -200,7 +242,7 @@ function parseCreateThreadRequest(payload: ContextJsonObject): NvimCreateThreadR
   const anchor = parseAnchor(payload);
   const startLine = getPositiveInteger(payload, "startLine", null);
   const endLine = getPositiveInteger(payload, "endLine", startLine);
-  if (!targetAgentId || !body || !anchor || startLine == null || endLine == null) return null;
+  if (!body || !anchor || startLine == null || endLine == null) return null;
   return {
     targetAgentId,
     body,
@@ -235,6 +277,18 @@ function parseListRequest(payload: ContextJsonObject): NvimListRequest | null {
     includeResolved: typeof payload.includeResolved === "boolean" ? payload.includeResolved : false,
     limit: getPositiveInteger(payload, "limit", 100) ?? 100,
   };
+}
+
+// agent-standards-ignore prefer-inline-single-use-helper: document payload parser is a named protocol DTO boundary.
+function parseDocumentRequest(payload: ContextJsonObject): NvimDocumentRequest | null {
+  const anchor = parseAnchor(payload);
+  return anchor ? { anchor } : null;
+}
+
+function parseDocumentAgentRequest(payload: ContextJsonObject): NvimDocumentAgentRequest | null {
+  const anchor = parseAnchor(payload);
+  const agentId = getString(payload, "agentId");
+  return anchor && agentId ? { anchor, agentId } : null;
 }
 
 function serializeMetadata(metadata: ContextualThreadMetadata): Record<string, ContextJsonValue> {
@@ -401,6 +455,14 @@ export class NvimPinetAdapter implements MessageAdapter {
         return this.listThreads(request.payload);
       case "pinet.thread.get":
         return this.getThread(request.payload);
+      case "pinet.document.get":
+        return this.getDocument(request.payload);
+      case "pinet.document.owner":
+        return this.setDocumentOwner(request.payload);
+      case "pinet.document.subscribe":
+        return this.subscribeDocument(request.payload, true);
+      case "pinet.document.unsubscribe":
+        return this.subscribeDocument(request.payload, false);
       default:
         throw new Error(`Unknown nvim request: ${request.type}`);
     }
@@ -408,16 +470,39 @@ export class NvimPinetAdapter implements MessageAdapter {
 
   private createThread(payload: ContextJsonObject): ContextJsonObject {
     const parsed = parseCreateThreadRequest(payload);
-    if (!parsed)
-      throw new Error("targetAgentId, body, anchor, startLine, and endLine are required");
+    if (!parsed) throw new Error("body, anchor, startLine, and endLine are required");
     if (
       parsed.anchor.repository !== this.options.repository ||
       parsed.anchor.worktree !== this.options.worktree
     ) {
       throw new Error("code anchor does not belong to this Pinet worktree");
     }
-    if (!this.options.getAgentById(parsed.targetAgentId)) {
-      throw new Error(`Unknown target agent: ${parsed.targetAgentId}`);
+    const documentId = buildGitFileDocumentId(parsed.anchor);
+    let document = this.options.db.getDocument(documentId);
+    const targetAgentId = parsed.targetAgentId ?? document?.ownerAgent ?? null;
+    if (!targetAgentId)
+      throw new Error("targetAgentId is required until this document has an owner");
+    if (!this.options.getAgentById(targetAgentId)) {
+      throw new Error(`Unknown target agent: ${targetAgentId}`);
+    }
+    if (!document) {
+      document = this.options.db.upsertDocument({
+        documentId,
+        kind: "git_file",
+        title: parsed.anchor.path,
+        ownerAgent: targetAgentId,
+        ownerBinding: "explicit",
+        metadata: {
+          repository: parsed.anchor.repository,
+          worktree: parsed.anchor.worktree,
+          path: parsed.anchor.path,
+        },
+      });
+      this.options.db.bindDocumentAlias(
+        "nvim",
+        `${parsed.anchor.repository}\0${parsed.anchor.worktree}\0${parsed.anchor.path}`,
+        documentId,
+      );
     }
     const metadata = buildContextualThreadMetadata({
       ...parsed.anchor,
@@ -432,20 +517,21 @@ export class NvimPinetAdapter implements MessageAdapter {
       threadId,
       source: "nvim",
       channel: this.repoSocketHash,
-      ownerAgent: parsed.targetAgentId,
+      ownerAgent: targetAgentId,
       ownerBinding: "explicit",
-      metadata: serializeMetadata(metadata),
+      metadata: { ...serializeMetadata(metadata), documentId },
       createdAt: now,
       updatedAt: now,
     });
     this.emitInbound(
       threadId,
-      parsed.targetAgentId,
+      targetAgentId,
       `${formatAnchorForMessage(metadata)}\n\n${parsed.body}`,
       {
         pinetKind: "contextual_thread_message",
         schemaVersion: 1,
         event: "thread.created",
+        documentId,
       },
     );
     return { threadId, metadata: serializeMetadata(metadata) };
@@ -456,10 +542,13 @@ export class NvimPinetAdapter implements MessageAdapter {
     if (!parsed) throw new Error("threadId and body are required");
     const thread = this.options.db.getThread(parsed.threadId);
     if (!thread) throw new Error(`Unknown thread: ${parsed.threadId}`);
+    const documentId =
+      typeof thread.metadata?.documentId === "string" ? thread.metadata.documentId : null;
     this.emitInbound(parsed.threadId, thread.ownerAgent ?? "", parsed.body, {
       pinetKind: "contextual_thread_message",
       schemaVersion: 1,
       event: "thread.reply",
+      ...(documentId ? { documentId } : {}),
     });
     return { threadId: parsed.threadId };
   }
@@ -472,17 +561,17 @@ export class NvimPinetAdapter implements MessageAdapter {
     if (!thread || !metadata) throw new Error(`Unknown contextual thread: ${parsed.threadId}`);
     const updated = updateContextualThreadResolvedState(metadata, parsed.resolved, "nvim");
     this.options.db.updateThread(parsed.threadId, { metadata: serializeMetadata(updated) });
-    this.options.db.insertMessage(
+    const documentId =
+      typeof thread.metadata?.documentId === "string" ? thread.metadata.documentId : null;
+    this.emitInbound(
       parsed.threadId,
-      "nvim",
-      "inbound",
-      "nvim",
+      thread.ownerAgent ?? "",
       parsed.resolved ? "Resolved this thread." : "Reopened this thread.",
-      thread.ownerAgent ? [thread.ownerAgent] : [],
       {
         pinetKind: "contextual_thread_message",
         schemaVersion: 1,
         event: parsed.resolved ? "thread.resolved" : "thread.reopened",
+        ...(documentId ? { documentId } : {}),
       },
     );
     this.broadcast({ type: "thread.updated", payload: { threadId: parsed.threadId } });
@@ -515,6 +604,108 @@ export class NvimPinetAdapter implements MessageAdapter {
     const metadata = parseContextualThreadMetadata(thread?.metadata as ContextJsonValue);
     if (!thread || !metadata) throw new Error(`Unknown contextual thread: ${threadId}`);
     return this.serializeThread(thread, metadata, 50);
+  }
+
+  private getDocument(payload: ContextJsonObject): ContextJsonObject {
+    const parsed = parseDocumentRequest(payload);
+    if (!parsed) throw new Error("revision-aware anchor is required");
+    const documentId = buildGitFileDocumentId(parsed.anchor);
+    const document = this.options.db.getDocument(documentId);
+    return {
+      documentId,
+      ownerAgentId: document?.ownerAgent ?? null,
+      subscribers: document ? this.options.db.listDocumentSubscribers(documentId) : [],
+    };
+  }
+
+  private setDocumentOwner(payload: ContextJsonObject): ContextJsonObject {
+    const parsed = parseDocumentAgentRequest(payload);
+    if (!parsed) throw new Error("anchor and agentId are required");
+    if (!this.options.getAgentById(parsed.agentId))
+      throw new Error(`Unknown agent: ${parsed.agentId}`);
+    const documentId = buildGitFileDocumentId(parsed.anchor);
+    if (!this.options.db.getDocument(documentId)) {
+      this.options.db.upsertDocument({
+        documentId,
+        kind: "git_file",
+        title: parsed.anchor.path,
+        ownerAgent: parsed.agentId,
+        ownerBinding: "explicit",
+        metadata: {
+          repository: parsed.anchor.repository,
+          worktree: parsed.anchor.worktree,
+          path: parsed.anchor.path,
+        },
+      });
+    } else {
+      this.options.db.setDocumentOwner(documentId, parsed.agentId);
+    }
+    this.options.db.bindDocumentAlias(
+      "nvim",
+      `${parsed.anchor.repository}\0${parsed.anchor.worktree}\0${parsed.anchor.path}`,
+      documentId,
+    );
+    this.emitDocumentEvent(
+      documentId,
+      parsed.agentId,
+      `Document owner changed to ${parsed.agentId}.`,
+      "document.owner_changed",
+    );
+    return this.getDocument({ anchor: parsed.anchor });
+  }
+
+  private subscribeDocument(payload: ContextJsonObject, subscribe: boolean): ContextJsonObject {
+    const parsed = parseDocumentAgentRequest(payload);
+    if (!parsed) throw new Error("anchor and agentId are required");
+    if (!this.options.getAgentById(parsed.agentId))
+      throw new Error(`Unknown agent: ${parsed.agentId}`);
+    const documentId = buildGitFileDocumentId(parsed.anchor);
+    if (!this.options.db.getDocument(documentId))
+      throw new Error(`Unknown document: ${documentId}`);
+    if (subscribe) this.options.db.subscribeDocument(documentId, parsed.agentId);
+    else this.options.db.unsubscribeDocument(documentId, parsed.agentId);
+    const document = this.options.db.getDocument(documentId)!;
+    this.emitDocumentEvent(
+      documentId,
+      document.ownerAgent ?? parsed.agentId,
+      subscribe
+        ? `${parsed.agentId} subscribed to this document.`
+        : `${parsed.agentId} unsubscribed from this document.`,
+      subscribe ? "document.subscribed" : "document.unsubscribed",
+    );
+    return this.getDocument({ anchor: parsed.anchor });
+  }
+
+  private emitDocumentEvent(
+    documentId: string,
+    ownerAgentId: string,
+    body: string,
+    event: string,
+  ): void {
+    const threadId = `document:${documentId}`;
+    const now = new Date().toISOString();
+    const existing = this.options.db.getThread(threadId);
+    if (!existing) {
+      this.options.db.createThread({
+        threadId,
+        source: "nvim",
+        channel: this.repoSocketHash,
+        ownerAgent: ownerAgentId,
+        ownerBinding: "explicit",
+        metadata: { pinetKind: "document_thread", documentId },
+        createdAt: now,
+        updatedAt: now,
+      });
+    } else if (existing.ownerAgent !== ownerAgentId) {
+      this.options.db.updateThread(threadId, { ownerAgent: ownerAgentId });
+    }
+    this.emitInbound(threadId, ownerAgentId, body, {
+      pinetKind: "document_message",
+      schemaVersion: 1,
+      event,
+      documentId,
+    });
+    this.broadcast({ type: "document.updated", payload: { documentId } });
   }
 
   private serializeThread(

--- a/slack-bridge/nvim-pinet-adapter.ts
+++ b/slack-bridge/nvim-pinet-adapter.ts
@@ -645,6 +645,14 @@ export class NvimPinetAdapter implements MessageAdapter {
       `${parsed.anchor.repository}\0${parsed.anchor.worktree}\0${parsed.anchor.path}`,
       documentId,
     );
+    for (const thread of this.options.db.getThreads()) {
+      if (thread.metadata?.documentId === documentId && thread.ownerAgent !== parsed.agentId) {
+        this.options.db.updateThread(thread.threadId, {
+          ownerAgent: parsed.agentId,
+          ownerBinding: "explicit",
+        });
+      }
+    }
     this.emitDocumentEvent(
       documentId,
       parsed.agentId,

--- a/slack-bridge/nvim-pinet-adapter.ts
+++ b/slack-bridge/nvim-pinet-adapter.ts
@@ -27,6 +27,7 @@ import type {
 export interface NvimAdapterDbPort {
   getThread(threadId: string): ThreadInfo | null;
   getDocument(documentId: string): DocumentInfo | null;
+  getDocumentByAlias(source: string, externalId: string): DocumentInfo | null;
   upsertDocument(document: Omit<DocumentInfo, "createdAt" | "updatedAt">): DocumentInfo;
   bindDocumentAlias(
     source: string,
@@ -109,6 +110,10 @@ interface NvimDocumentRequest {
   anchor: CodeRevisionIdentity;
 }
 
+interface NvimBindThreadRequest extends NvimDocumentRequest {
+  threadId: string;
+}
+
 interface NvimEditorState {
   file: string | null;
   line: number | null;
@@ -147,11 +152,16 @@ export function resolveNvimRepositoryContext(cwd: string): NvimRepositoryContext
   }
 }
 
+export function buildGitFileAliasExternalId(
+  anchor: Pick<CodeRevisionIdentity, "repository" | "worktree" | "path">,
+): string {
+  return `${anchor.repository}\0${anchor.worktree}\0${anchor.path}`;
+}
+
 export function buildGitFileDocumentId(
   anchor: Pick<CodeRevisionIdentity, "repository" | "worktree" | "path">,
 ): string {
-  const identity = `${anchor.repository}\0${anchor.worktree}\0${anchor.path}`;
-  return `doc:git-file:${createHash("sha256").update(identity).digest("hex")}`;
+  return `doc:git-file:${createHash("sha256").update(buildGitFileAliasExternalId(anchor)).digest("hex")}`;
 }
 
 function computeRepoSocketHash(worktree: string, branch: string): string {
@@ -283,6 +293,12 @@ function parseListRequest(payload: ContextJsonObject): NvimListRequest | null {
 function parseDocumentRequest(payload: ContextJsonObject): NvimDocumentRequest | null {
   const anchor = parseAnchor(payload);
   return anchor ? { anchor } : null;
+}
+
+function parseBindThreadRequest(payload: ContextJsonObject): NvimBindThreadRequest | null {
+  const anchor = parseAnchor(payload);
+  const threadId = getString(payload, "threadId");
+  return anchor && threadId ? { anchor, threadId } : null;
 }
 
 function parseDocumentAgentRequest(payload: ContextJsonObject): NvimDocumentAgentRequest | null {
@@ -463,9 +479,18 @@ export class NvimPinetAdapter implements MessageAdapter {
         return this.subscribeDocument(request.payload, true);
       case "pinet.document.unsubscribe":
         return this.subscribeDocument(request.payload, false);
+      case "pinet.document.bind_thread":
+        return this.bindDocumentThread(request.payload);
       default:
         throw new Error(`Unknown nvim request: ${request.type}`);
     }
+  }
+
+  private resolveGitDocument(anchor: CodeRevisionIdentity): DocumentInfo | null {
+    return (
+      this.options.db.getDocumentByAlias("nvim", buildGitFileAliasExternalId(anchor)) ??
+      this.options.db.getDocument(buildGitFileDocumentId(anchor))
+    );
   }
 
   private createThread(payload: ContextJsonObject): ContextJsonObject {
@@ -477,8 +502,8 @@ export class NvimPinetAdapter implements MessageAdapter {
     ) {
       throw new Error("code anchor does not belong to this Pinet worktree");
     }
-    const documentId = buildGitFileDocumentId(parsed.anchor);
-    let document = this.options.db.getDocument(documentId);
+    let document = this.resolveGitDocument(parsed.anchor);
+    const documentId = document?.documentId ?? buildGitFileDocumentId(parsed.anchor);
     const targetAgentId = parsed.targetAgentId ?? document?.ownerAgent ?? null;
     if (!targetAgentId)
       throw new Error("targetAgentId is required until this document has an owner");
@@ -500,7 +525,7 @@ export class NvimPinetAdapter implements MessageAdapter {
       });
       this.options.db.bindDocumentAlias(
         "nvim",
-        `${parsed.anchor.repository}\0${parsed.anchor.worktree}\0${parsed.anchor.path}`,
+        buildGitFileAliasExternalId(parsed.anchor),
         documentId,
       );
     }
@@ -609,8 +634,8 @@ export class NvimPinetAdapter implements MessageAdapter {
   private getDocument(payload: ContextJsonObject): ContextJsonObject {
     const parsed = parseDocumentRequest(payload);
     if (!parsed) throw new Error("revision-aware anchor is required");
-    const documentId = buildGitFileDocumentId(parsed.anchor);
-    const document = this.options.db.getDocument(documentId);
+    const document = this.resolveGitDocument(parsed.anchor);
+    const documentId = document?.documentId ?? buildGitFileDocumentId(parsed.anchor);
     return {
       documentId,
       ownerAgentId: document?.ownerAgent ?? null,
@@ -623,8 +648,9 @@ export class NvimPinetAdapter implements MessageAdapter {
     if (!parsed) throw new Error("anchor and agentId are required");
     if (!this.options.getAgentById(parsed.agentId))
       throw new Error(`Unknown agent: ${parsed.agentId}`);
-    const documentId = buildGitFileDocumentId(parsed.anchor);
-    if (!this.options.db.getDocument(documentId)) {
+    const existingDocument = this.resolveGitDocument(parsed.anchor);
+    const documentId = existingDocument?.documentId ?? buildGitFileDocumentId(parsed.anchor);
+    if (!existingDocument) {
       this.options.db.upsertDocument({
         documentId,
         kind: "git_file",
@@ -642,7 +668,7 @@ export class NvimPinetAdapter implements MessageAdapter {
     }
     this.options.db.bindDocumentAlias(
       "nvim",
-      `${parsed.anchor.repository}\0${parsed.anchor.worktree}\0${parsed.anchor.path}`,
+      buildGitFileAliasExternalId(parsed.anchor),
       documentId,
     );
     for (const thread of this.options.db.getThreads()) {
@@ -667,19 +693,72 @@ export class NvimPinetAdapter implements MessageAdapter {
     if (!parsed) throw new Error("anchor and agentId are required");
     if (!this.options.getAgentById(parsed.agentId))
       throw new Error(`Unknown agent: ${parsed.agentId}`);
-    const documentId = buildGitFileDocumentId(parsed.anchor);
-    if (!this.options.db.getDocument(documentId))
-      throw new Error(`Unknown document: ${documentId}`);
+    const document = this.resolveGitDocument(parsed.anchor);
+    const documentId = document?.documentId ?? buildGitFileDocumentId(parsed.anchor);
+    if (!document) throw new Error(`Unknown document: ${documentId}`);
     if (subscribe) this.options.db.subscribeDocument(documentId, parsed.agentId);
     else this.options.db.unsubscribeDocument(documentId, parsed.agentId);
-    const document = this.options.db.getDocument(documentId)!;
+    const updatedDocument = this.options.db.getDocument(documentId)!;
     this.emitDocumentEvent(
       documentId,
-      document.ownerAgent ?? parsed.agentId,
+      updatedDocument.ownerAgent ?? parsed.agentId,
       subscribe
         ? `${parsed.agentId} subscribed to this document.`
         : `${parsed.agentId} unsubscribed from this document.`,
       subscribe ? "document.subscribed" : "document.unsubscribed",
+    );
+    return this.getDocument({ anchor: parsed.anchor });
+  }
+
+  private bindDocumentThread(payload: ContextJsonObject): ContextJsonObject {
+    const parsed = parseBindThreadRequest(payload);
+    if (!parsed) throw new Error("anchor and threadId are required");
+    const document = this.resolveGitDocument(parsed.anchor);
+    if (!document?.ownerAgent)
+      throw new Error("Set a document owner before binding a Slack thread");
+    const thread = this.options.db.getThread(parsed.threadId);
+    if (!thread || thread.source !== "slack") {
+      throw new Error(`Unknown Slack thread: ${parsed.threadId}`);
+    }
+
+    const previousDocumentId =
+      typeof thread.metadata?.documentId === "string" ? thread.metadata.documentId : null;
+    if (previousDocumentId && previousDocumentId !== document.documentId) {
+      for (const subscriber of this.options.db.listDocumentSubscribers(previousDocumentId)) {
+        this.options.db.subscribeDocument(document.documentId, subscriber);
+      }
+    }
+    const referenceExternalId = `${thread.channel}\0${thread.threadId}`;
+    this.options.db.bindDocumentAlias(
+      "slack-thread-ref",
+      referenceExternalId,
+      document.documentId,
+      { channelId: thread.channel, threadTs: thread.threadId },
+    );
+    const scopedExternalId =
+      typeof thread.metadata?.documentAliasExternalId === "string"
+        ? thread.metadata.documentAliasExternalId
+        : null;
+    if (scopedExternalId) {
+      this.options.db.bindDocumentAlias("slack", scopedExternalId, document.documentId, {
+        channelId: thread.channel,
+        threadTs: thread.threadId,
+      });
+    }
+    this.options.db.updateThread(thread.threadId, {
+      ownerAgent: document.ownerAgent,
+      ownerBinding: "explicit",
+      metadata: {
+        ...(thread.metadata ?? {}),
+        documentId: document.documentId,
+        documentReferenceExternalId: referenceExternalId,
+      },
+    });
+    this.emitDocumentEvent(
+      document.documentId,
+      document.ownerAgent,
+      `Bound Slack thread ${thread.channel}/${thread.threadId} to this document.`,
+      "document.thread_bound",
     );
     return this.getDocument({ anchor: parsed.anchor });
   }

--- a/slack-bridge/slack-pinet-runtime-adapter.ts
+++ b/slack-bridge/slack-pinet-runtime-adapter.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { SlackAdapter } from "./broker/adapters/slack.js";
 import type { Broker, ThreadInfo } from "./broker/index.js";
@@ -71,12 +72,33 @@ function rememberKnownSlackThread(
   channelId: string,
   context?: ParsedThreadStarted["context"] | null,
 ): void {
-  const existingMetadata = broker.db.getThread(threadTs)?.metadata ?? {};
+  const existing = broker.db.getThread(threadTs);
+  const existingMetadata = existing?.metadata ?? {};
+  const scopeKey = context ? JSON.stringify(context.scope) : "workspace";
+  const externalId = `${scopeKey}\0${channelId}\0${threadTs}`;
+  const documentId = `doc:slack-thread:${createHash("sha256").update(externalId).digest("hex")}`;
+  broker.db.upsertDocument({
+    documentId,
+    kind: "slack_thread",
+    title: `Slack ${channelId}/${threadTs}`,
+    ownerAgent: existing?.ownerAgent ?? null,
+    ownerBinding: existing?.ownerBinding ?? null,
+    metadata: {
+      channelId,
+      threadTs,
+      ...(context ? { slackThreadContext: context } : {}),
+    },
+  });
+  broker.db.bindDocumentAlias("slack", externalId, documentId, {
+    channelId,
+    threadTs,
+  });
   broker.db.updateThread(threadTs, {
     source: "slack",
     channel: channelId,
     metadata: {
       ...existingMetadata,
+      documentId,
       ...(context ? { slackThreadContext: context } : {}),
     },
   });

--- a/slack-bridge/slack-pinet-runtime-adapter.ts
+++ b/slack-bridge/slack-pinet-runtime-adapter.ts
@@ -76,20 +76,32 @@ function rememberKnownSlackThread(
   const existingMetadata = existing?.metadata ?? {};
   const scopeKey = context ? JSON.stringify(context.scope) : "workspace";
   const externalId = `${scopeKey}\0${channelId}\0${threadTs}`;
-  const documentId = `doc:slack-thread:${createHash("sha256").update(externalId).digest("hex")}`;
-  broker.db.upsertDocument({
-    documentId,
-    kind: "slack_thread",
-    title: `Slack ${channelId}/${threadTs}`,
-    ownerAgent: existing?.ownerAgent ?? null,
-    ownerBinding: existing?.ownerBinding ?? null,
-    metadata: {
-      channelId,
-      threadTs,
-      ...(context ? { slackThreadContext: context } : {}),
-    },
-  });
+  const referenceExternalId = `${channelId}\0${threadTs}`;
+  const aliasedDocument =
+    broker.db.getDocumentByAlias("slack-thread-ref", referenceExternalId) ??
+    broker.db.getDocumentByAlias("slack", externalId);
+  const documentId =
+    aliasedDocument?.documentId ??
+    `doc:slack-thread:${createHash("sha256").update(externalId).digest("hex")}`;
+  if (!aliasedDocument) {
+    broker.db.upsertDocument({
+      documentId,
+      kind: "slack_thread",
+      title: `Slack ${channelId}/${threadTs}`,
+      ownerAgent: existing?.ownerAgent ?? null,
+      ownerBinding: existing?.ownerBinding ?? null,
+      metadata: {
+        channelId,
+        threadTs,
+        ...(context ? { slackThreadContext: context } : {}),
+      },
+    });
+  }
   broker.db.bindDocumentAlias("slack", externalId, documentId, {
+    channelId,
+    threadTs,
+  });
+  broker.db.bindDocumentAlias("slack-thread-ref", referenceExternalId, documentId, {
     channelId,
     threadTs,
   });
@@ -99,6 +111,8 @@ function rememberKnownSlackThread(
     metadata: {
       ...existingMetadata,
       documentId,
+      documentAliasExternalId: externalId,
+      documentReferenceExternalId: referenceExternalId,
       ...(context ? { slackThreadContext: context } : {}),
     },
   });


### PR DESCRIPTION
## Summary

- allow `:PinetComment` and exact-revision sign restoration in ordinary tracked Neovim buffers, including unsaved buffer blob identity
- add a transport-neutral BrokerDB document domain with durable owner, aliases, and agent subscriptions
- fan document activity and agent replies out to the unique owner/subscriber set while preserving single thread ownership
- bind both canonical Neovim Git files and known Slack threads through document aliases
- add document owner/subscription commands and preserve existing Fugitive/native diff behavior

## Neovim commands

- `:PinetOwner [agent_id]`
- `:PinetSubscribe [agent_id]`
- `:PinetUnsubscribe [agent_id]`
- `:PinetSubscribers`
- `:PinetComment [body]` now works in tracked normal buffers and keeps visual ranges

## Validation

- `pnpm prepush`
- broker-core: 225 tests passed
- slack-bridge: 1714 tests passed, 3 skipped
- nvim-bridge: 10 tests passed
- agent-standards lint passed

Closes #1022
