### PR TITLE
release: v0.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ themselves create a new release entry, tag, or package version. Add a versioned
 entry only when a maintainer approves a real release with intentional package
 version bumps and publish scope.
 
-## [0.2.13] - 2026-08-27
+## [0.2.13] - 2026-08-28
 
 Pinet v0.2.13 extends contextual threads to normal tracked Neovim buffers and introduces broker-owned, transport-neutral document ownership and subscriptions shared across Neovim and Slack.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ themselves create a new release entry, tag, or package version. Add a versioned
 entry only when a maintainer approves a real release with intentional package
 version bumps and publish scope.
 
+## [0.2.13] - 2026-08-27
+
+Pinet v0.2.13 extends contextual threads to normal tracked Neovim buffers and introduces broker-owned, transport-neutral document ownership and subscriptions shared across Neovim and Slack.
+
+### Version verification
+
+- `pi-extensions` — `0.2.13` (private repo package)
+- `@pinet/transport-core` — `0.2.13`
+- `@pinet/broker-core` — `0.2.13`
+- `@pinet/pinet-core` — `0.2.13`
+- `@pinet/imessage-bridge` — `0.2.13`
+- `@pinet/slack-bridge` — `0.2.13`
+- `@pinet/model-aware-compaction` — `0.2.13`
+- `@pinet/agent-goal` — `0.2.13`
+
+### Release highlights
+
+- Enables `:PinetComment` in normal tracked buffers with revision-aware schema-v2 anchors that do not invent diff sides, while preserving schema-v1 diff anchors.
+- Adds broker-persisted documents, aliases, one authoritative owner, and deduplicated subscribers without introducing transport-specific ownership stores.
+- Adds Neovim ownership and subscription commands plus explicit `:PinetBindSlack <thread_id>` binding so Slack and Git-file aliases resolve to one canonical document.
+- Preserves delivery to durable resumable or hibernated owners and subscribers even when they are not in the live process roster.
+- Migrates BrokerDB from schema v24 to v25 while preserving existing threads and validates restart persistence, ownership transfer, fanout, alias resolution, and legacy anchors.
+
+### Notable pull requests
+
+- [#1023](https://github.com/gugu91/pinet/pull/1023) — add normal-buffer contextual threads and shared document ownership/subscriptions
+
+See the [full change set since v0.2.12](https://github.com/gugu91/pinet/compare/v0.2.12...v0.2.13).
+
 ## [0.2.12] - 2026-08-26
 
 Pinet v0.2.12 replaces the dormant PiComms review store with Pinet-native, revision-aware contextual threads for single-file Neovim diffs.

--- a/agent-goal/package.json
+++ b/agent-goal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/agent-goal",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "description": "Standalone single-agent durable goal loop for Pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/broker-core/package.json
+++ b/broker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/broker-core",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "description": "Transport-neutral broker kernel primitives for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/imessage-bridge/package.json
+++ b/imessage-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/imessage-bridge",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "description": "macOS/iMessage send-first adapter and readiness helpers for pi",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/model-aware-compaction/package.json
+++ b/model-aware-compaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/model-aware-compaction",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "description": "Pi extension for proactive model-aware context compaction thresholds",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-extensions",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/pinet-core/package.json
+++ b/pinet-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/pinet-core",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "description": "Pinet runtime core for pi — broker/follower orchestration and mesh tooling",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/slack-bridge/package.json
+++ b/slack-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/slack-bridge",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "description": "Pi package for Pinet Slack assistant integration — multi-agent broker, thread routing, and inbox tools",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",

--- a/transport-core/package.json
+++ b/transport-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinet/transport-core",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "description": "Transport-neutral message contracts for pi transports",
   "author": "Will Porcellini <5994936+gugu91@users.noreply.github.com>",


### PR DESCRIPTION
Closes #1024.

## Summary

- bump the private root and all seven coordinated `@pinet/*` packages to `0.2.13`
- document normal tracked-buffer contextual threads and broker-owned document ownership/subscriptions
- release the cross-adapter Slack/Neovim alias binding and durable offline recipient fixes from #1023

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm prepush`
- `pnpm publish:npm` (guarded dry-run for all seven packages)

## Publish plan

After approval and merge, tag the current `main` tip as `v0.2.13`, create the GitHub release, approve the protected `npm-publish` environment, verify all seven npm versions, and install `npm:@pinet/slack-bridge@0.2.13` locally.
