### PR TITLE
fix(broker): non-owning broker shutdown can no longer unlink the live owner's socket (+ cross-process replace-lifecycle E2E)

### DIFF
--- a/slack-bridge/broker/replace-lifecycle.test.ts
+++ b/slack-bridge/broker/replace-lifecycle.test.ts
@@ -1,0 +1,295 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { BrokerDB } from "./schema.js";
+import { BrokerSocketServer } from "./socket-server.js";
+import { startBroker } from "./index.js";
+import { inspectBrokerLock, readBrokerLockOwner } from "./leader.js";
+import { probeBrokerSocket, replaceBrokerOwner } from "./lock-conflict.js";
+
+// ─── Cross-process replace-lifecycle E2E (#953) ──────────
+//
+// A real broker child process acquires the real leader lock and serves
+// `admin.shutdown` on a real socket, while this (parent) process drives the
+// `/pinet start replace` composition against it: graceful shutdown RPC →
+// wait for lock release → successor acquisition. Timeouts are generous and
+// the assertion set deliberately small to stay CI-stable.
+
+const REPO_ROOT = fileURLToPath(new URL("../../", import.meta.url));
+
+type ChildMode = "graceful" | "holdout" | "socket-holdout";
+
+/**
+ * Child program: resolves the repo's `.ts` sources under plain `node` (the
+ * sources use `.js` specifiers and `@pinet/*` workspace imports, and built
+ * dist output may be absent or stale), then runs one broker child mode:
+ *
+ * - `graceful`       — real `startBroker`; `admin.shutdown` stops the broker.
+ * - `holdout`        — real `startBroker`; accepts `admin.shutdown` but never
+ *                      releases (the fenced-SIGTERM escalation target).
+ * - `socket-holdout` — socket server only; keeps serving until gated, then
+ *                      runs its own `stop()` after the parent has taken over
+ *                      the socket path.
+ */
+const CHILD_SOURCE = `
+import { registerHooks } from "node:module";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repoRoot = process.argv[2];
+const mode = process.argv[3];
+const dir = process.argv[4];
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    const scoped = specifier.match(/^@pinet\\/([^/]+)(?:\\/(.+))?$/);
+    if (scoped) {
+      const target = path.join(repoRoot, scoped[1], (scoped[2] ?? "index") + ".ts");
+      return { url: pathToFileURL(target).href, shortCircuit: true };
+    }
+    if (
+      specifier.endsWith(".js") &&
+      specifier.startsWith(".") &&
+      context.parentURL?.startsWith("file:")
+    ) {
+      const tsPath = path.resolve(
+        path.dirname(fileURLToPath(context.parentURL)),
+        specifier.slice(0, -3) + ".ts",
+      );
+      if (fs.existsSync(tsPath)) {
+        return { url: pathToFileURL(tsPath).href, shortCircuit: true };
+      }
+    }
+    return nextResolve(specifier, context);
+  },
+});
+
+const broker = await import(
+  pathToFileURL(path.join(repoRoot, "slack-bridge/broker/index.ts")).href
+);
+
+const socketPath = path.join(dir, "s.sock");
+const readyPath = path.join(dir, "ready.json");
+const gatePath = path.join(dir, "gate");
+const resultPath = path.join(dir, "result.json");
+const acceptedPath = path.join(dir, "accepted");
+
+if (mode === "socket-holdout") {
+  const db = new broker.BrokerDB(path.join(dir, "child.db"));
+  db.initialize();
+  const server = new broker.BrokerSocketServer(db, socketPath);
+  await server.start();
+  fs.writeFileSync(readyPath, JSON.stringify({ pid: process.pid, instanceId: null }));
+  const poll = setInterval(() => {
+    if (!fs.existsSync(gatePath)) return;
+    clearInterval(poll);
+    void server.stop().then(() => {
+      db.close();
+      fs.writeFileSync(resultPath, JSON.stringify({ stopped: true }));
+      process.exit(0);
+    });
+  }, 50);
+} else {
+  const running = await broker.startBroker({
+    lockPath: path.join(dir, "lock"),
+    dbPath: path.join(dir, "child.db"),
+    socketPath,
+  });
+  running.server.setAdminShutdownHandler(() => {
+    fs.writeFileSync(acceptedPath, "accepted");
+    if (mode !== "graceful") return; // holdout: accept but never release
+    void running.stop().then(() => {
+      fs.writeFileSync(resultPath, JSON.stringify({ stopped: true }));
+      process.exit(0);
+    });
+  });
+  fs.writeFileSync(
+    readyPath,
+    JSON.stringify({ pid: process.pid, instanceId: running.lock.getInstanceId() }),
+  );
+}
+`;
+
+interface SpawnedBrokerChild {
+  child: ChildProcess;
+  exited: Promise<void>;
+}
+
+describe("cross-process /pinet start replace lifecycle", () => {
+  let dir: string;
+  let spawned: SpawnedBrokerChild | null;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "r953-"));
+    spawned = null;
+  });
+
+  afterEach(async () => {
+    if (spawned) {
+      const { child, exited } = spawned;
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      await exited.catch(() => {});
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const lockPath = (): string => path.join(dir, "lock");
+  const socketPath = (): string => path.join(dir, "s.sock");
+  const childStderrPath = (): string => path.join(dir, "child-stderr.log");
+
+  function spawnBrokerChild(mode: ChildMode): SpawnedBrokerChild {
+    const script = path.join(dir, "broker-child.mjs");
+    fs.writeFileSync(script, CHILD_SOURCE, "utf-8");
+    const stderr = fs.openSync(childStderrPath(), "w");
+    const child = spawn(
+      process.execPath,
+      ["--no-warnings", "--experimental-transform-types", script, REPO_ROOT, mode, dir],
+      { stdio: ["ignore", "ignore", stderr] },
+    );
+    fs.closeSync(stderr);
+    // Attach the exit promise immediately — a listener attached after the
+    // event has fired never resolves.
+    const exited = new Promise<void>((resolve, reject) => {
+      child.on("error", reject);
+      child.on("exit", () => resolve());
+    });
+    spawned = { child, exited };
+    return spawned;
+  }
+
+  async function waitForFile(filePath: string, what: string, timeoutMs = 20_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (!fs.existsSync(filePath)) {
+      if (Date.now() > deadline) {
+        let childLog = "";
+        try {
+          childLog = fs.readFileSync(childStderrPath(), "utf-8");
+        } catch {
+          /* no log */
+        }
+        throw new Error(`Timed out waiting for ${what}.\nChild stderr:\n${childLog}`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+
+  async function waitForChildReady(): Promise<{ pid: number; instanceId: string | null }> {
+    const readyPath = path.join(dir, "ready.json");
+    await waitForFile(readyPath, "broker child readiness");
+    return JSON.parse(fs.readFileSync(readyPath, "utf-8")) as {
+      pid: number;
+      instanceId: string | null;
+    };
+  }
+
+  it("replaces a live broker gracefully and hands the lock to the successor exactly once", async () => {
+    const { child, exited } = spawnBrokerChild("graceful");
+    const ready = await waitForChildReady();
+
+    // The child holds the real lock and serves the real socket.
+    const before = readBrokerLockOwner(lockPath());
+    expect(before?.pid).toBe(ready.pid);
+    expect(before?.instanceId).toBe(ready.instanceId);
+    expect(await probeBrokerSocket({ socketPath: socketPath() })).toBe("healthy");
+
+    const result = await replaceBrokerOwner({
+      lockPath: lockPath(),
+      socketPath: socketPath(),
+      shutdownRpcTimeoutMs: 10_000,
+      gracefulWaitMs: 20_000,
+      pollIntervalMs: 100,
+    });
+    expect(result.outcome).toBe("replaced-graceful");
+    expect(result.owner?.pid).toBe(ready.pid);
+
+    // The old owner released its own lock — nothing reclaimed it forcibly.
+    expect(inspectBrokerLock(lockPath()).state).toBe("none");
+    await waitForFile(path.join(dir, "result.json"), "broker child shutdown result");
+    await exited;
+    expect(child.exitCode).toBe(0);
+
+    // Successor acquisition: the lock changes hands to this process and the
+    // socket serves again.
+    const successor = await startBroker({
+      lockPath: lockPath(),
+      dbPath: path.join(dir, "successor.db"),
+      socketPath: socketPath(),
+    });
+    try {
+      const after = readBrokerLockOwner(lockPath());
+      expect(after?.pid).toBe(process.pid);
+      expect(after?.instanceId).toBe(successor.lock.getInstanceId());
+      expect(await probeBrokerSocket({ socketPath: socketPath() })).toBe("healthy");
+    } finally {
+      await successor.stop();
+    }
+  }, 45_000);
+
+  it("escalates to fenced SIGTERM when the owner accepts the shutdown RPC but never releases", async () => {
+    const { child, exited } = spawnBrokerChild("holdout");
+    const ready = await waitForChildReady();
+    expect(await probeBrokerSocket({ socketPath: socketPath() })).toBe("healthy");
+
+    const result = await replaceBrokerOwner({
+      lockPath: lockPath(),
+      socketPath: socketPath(),
+      shutdownRpcTimeoutMs: 10_000,
+      gracefulWaitMs: 1_500,
+      terminateWaitMs: 20_000,
+      pollIntervalMs: 100,
+    });
+    expect(result.outcome).toBe("replaced-terminated");
+    expect(result.owner?.pid).toBe(ready.pid);
+    // The child accepted the RPC — this exercised the escalation, not a
+    // broker that never got the request.
+    expect(fs.existsSync(path.join(dir, "accepted"))).toBe(true);
+
+    await exited;
+    expect(child.signalCode).toBe("SIGTERM");
+
+    // The stale lock the terminated owner left behind is reclaimed by a
+    // normal successor start.
+    const successor = await startBroker({
+      lockPath: lockPath(),
+      dbPath: path.join(dir, "successor.db"),
+      socketPath: socketPath(),
+    });
+    try {
+      expect(readBrokerLockOwner(lockPath())?.pid).toBe(process.pid);
+      expect(await probeBrokerSocket({ socketPath: socketPath() })).toBe("healthy");
+    } finally {
+      await successor.stop();
+    }
+  }, 45_000);
+
+  it("preserves the successor's live socket when the replaced owner shuts down late (#953)", async () => {
+    const { exited } = spawnBrokerChild("socket-holdout");
+    await waitForChildReady();
+    expect(await probeBrokerSocket({ socketPath: socketPath() })).toBe("healthy");
+
+    // Successor takeover of the socket path while the old owner still runs.
+    const successorDb = new BrokerDB(path.join(dir, "successor.db"));
+    successorDb.initialize();
+    const successor = new BrokerSocketServer(successorDb, socketPath());
+    await successor.start();
+    try {
+      // Gate open: the old owner now runs its own stop() in its own process.
+      fs.writeFileSync(path.join(dir, "gate"), "go", "utf-8");
+      await waitForFile(path.join(dir, "result.json"), "old owner shutdown result");
+      await exited;
+
+      // The non-owning shutdown must not have severed the live successor.
+      expect(fs.existsSync(socketPath())).toBe(true);
+      expect(await probeBrokerSocket({ socketPath: socketPath() })).toBe("healthy");
+    } finally {
+      await successor.stop();
+      successorDb.close();
+    }
+    // The live owner's own shutdown still cleans up the socket file.
+    expect(fs.existsSync(socketPath())).toBe(false);
+  }, 45_000);
+});

--- a/slack-bridge/broker/socket-server.test.ts
+++ b/slack-bridge/broker/socket-server.test.ts
@@ -1,0 +1,74 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { BrokerDB } from "./schema.js";
+import { BrokerSocketServer } from "./socket-server.js";
+import { probeBrokerSocket } from "./lock-conflict.js";
+
+// ─── Helpers ─────────────────────────────────────────────
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "sock-srv-"));
+}
+
+// ─── Unix socket file lifecycle (#953) ───────────────────
+//
+// stop() must unlink the socket path only while it still holds the socket
+// this server bound. A successor broker binds a fresh socket at the same
+// path during takeover; a late shutdown of the previous owner must never
+// sever it.
+
+describe("BrokerSocketServer unix socket file lifecycle", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("stop() removes the socket file it bound", async () => {
+    const db = new BrokerDB(path.join(dir, "a.db"));
+    db.initialize();
+    const sockPath = path.join(dir, "s.sock");
+    const server = new BrokerSocketServer(db, sockPath);
+    await server.start();
+    expect(fs.existsSync(sockPath)).toBe(true);
+
+    await server.stop();
+    db.close();
+    expect(fs.existsSync(sockPath)).toBe(false);
+  });
+
+  it("stop() preserves a successor's socket bound at the same path", async () => {
+    const sockPath = path.join(dir, "s.sock");
+    const previousDb = new BrokerDB(path.join(dir, "a.db"));
+    previousDb.initialize();
+    const previous = new BrokerSocketServer(previousDb, sockPath);
+    await previous.start();
+
+    // Successor takeover: start() replaces the stale-looking file with a
+    // fresh socket bound by the successor.
+    const successorDb = new BrokerDB(path.join(dir, "b.db"));
+    successorDb.initialize();
+    const successor = new BrokerSocketServer(successorDb, sockPath);
+    await successor.start();
+
+    try {
+      // The previous owner's shutdown must not unlink the successor's socket.
+      await previous.stop();
+      previousDb.close();
+      expect(fs.existsSync(sockPath)).toBe(true);
+      expect(await probeBrokerSocket({ socketPath: sockPath })).toBe("healthy");
+    } finally {
+      await successor.stop();
+      successorDb.close();
+    }
+
+    // The live owner's own shutdown still cleans up.
+    expect(fs.existsSync(sockPath)).toBe(false);
+  });
+});

--- a/slack-bridge/broker/socket-server.ts
+++ b/slack-bridge/broker/socket-server.ts
@@ -185,6 +185,13 @@ export class BrokerSocketServer {
   private readonly meshSecret: string | null;
   private pruneTimer: ReturnType<typeof setInterval> | null = null;
   private assignedPort: number | null = null;
+  /**
+   * Identity (device + inode) of the Unix socket file this server created at
+   * bind time. `stop()` only unlinks the socket path while it still carries
+   * this identity — a successor broker may have already bound a fresh socket
+   * at the same path, and a non-owning shutdown must never sever it (#953).
+   */
+  private boundUnixSocketId: { dev: number; ino: number } | null = null;
   private agentMessageCallback: AgentMessageCallback | null = null;
   private agentStatusChangeCallback: AgentStatusChangeCallback | null = null;
   private outboundMessageAdapters: ReadonlyArray<
@@ -218,11 +225,7 @@ export class BrokerSocketServer {
   }
 
   async start(): Promise<void> {
-    // Clean up stale socket file for Unix mode
     if (this.target.type === "unix") {
-      if (fs.existsSync(this.target.path)) {
-        fs.unlinkSync(this.target.path);
-      }
       fs.mkdirSync(path.dirname(this.target.path), { recursive: true });
     }
 
@@ -234,7 +237,33 @@ export class BrokerSocketServer {
       });
 
       if (this.target.type === "unix") {
-        this.server.listen(this.target.path, () => {
+        const socketPath = this.target.path;
+        // Bind a uniquely named socket, then atomically rename it over the
+        // target path. The takeover swap needs no unlink window, and the
+        // handle only ever remembers the temporary name — so the automatic
+        // unlink Node performs when a server closes targets that (already
+        // renamed-away) name and can never remove a successor's socket
+        // bound at the target path after ownership moved on (#953). The
+        // suffix is kept to 9 chars: sun_path allows ~104 bytes on macOS,
+        // and a hard-crashed broker leaves at worst one inert temp file
+        // beside its stale socket path.
+        const tempPath = `${socketPath}.${crypto.randomBytes(4).toString("hex")}`;
+        this.server.listen(tempPath, () => {
+          try {
+            const stat = fs.statSync(tempPath);
+            fs.renameSync(tempPath, socketPath);
+            this.boundUnixSocketId = { dev: stat.dev, ino: stat.ino };
+          } catch (err) {
+            this.server?.close();
+            this.server = null;
+            try {
+              fs.unlinkSync(tempPath);
+            } catch {
+              /* already gone */
+            }
+            reject(err instanceof Error ? err : new Error(String(err)));
+            return;
+          }
           this.startPruning();
           resolve();
         });
@@ -271,16 +300,31 @@ export class BrokerSocketServer {
         return;
       }
       this.server.close(() => {
-        // Clean up socket file for Unix mode
-        if (this.target.type === "unix") {
+        // Clean up the socket file for Unix mode — but only while the path
+        // still holds the socket this server bound. After a takeover the
+        // path belongs to the live successor, and unlinking it would leave
+        // that broker serving an unreachable, unnamed inode.
+        //
+        // The stat + unlink pair is not atomic (POSIX offers no unlink-by-
+        // inode), but a successor only binds this path while holding the
+        // leader lock, and the old owner releases that lock strictly after
+        // stop() resolves — so a takeover cannot slip into the window
+        // unless the lock protocol is already broken. Same accepted
+        // residual-window pattern as replaceBrokerOwner's SIGTERM fence.
+        if (this.target.type === "unix" && this.boundUnixSocketId) {
           try {
-            if (fs.existsSync(this.target.path)) {
+            const stat = fs.statSync(this.target.path);
+            if (
+              stat.dev === this.boundUnixSocketId.dev &&
+              stat.ino === this.boundUnixSocketId.ino
+            ) {
               fs.unlinkSync(this.target.path);
             }
           } catch {
-            // best effort
+            // already gone — nothing to clean up
           }
         }
+        this.boundUnixSocketId = null;
         this.server = null;
         this.assignedPort = null;
         resolve();


### PR DESCRIPTION
Closes #953.

## Problem

Issue #953 asked for cross-process E2E coverage of the `/pinet start replace` lifecycle. Writing it surfaced a real split-brain defect at the socket lifecycle seam, so this PR (with maintainer approval) fixes it and covers both.

A broker whose shutdown outlives its ownership of the socket path could sever the live successor:

1. `BrokerSocketServer.stop()` unlinked the socket path unconditionally.
2. Deeper: **Node itself unlinks the bound pathname when a unix server closes** (verified empirically on Node 25/macOS — closing server A removes the file even after server B bound a fresh socket at the same path). Fencing only the explicit unlink is therefore insufficient.

Result: a replaced owner's late teardown could remove the socket the successor had just bound, leaving the live broker serving an unreachable, unnamed inode.

## Fix (`slack-bridge/broker/socket-server.ts`)

- `start()` binds a uniquely named temp socket and atomically `rename()`s it over the target path. Takeover needs no unlink window, and the handle only remembers the (already renamed-away) temp name — so Node's close-time auto-unlink can never remove a successor's socket at the target path.
- `stop()` fences its explicit cleanup on the dev+inode identity captured at bind time: it removes the socket file only while the path still holds the socket this server created.
- The temp suffix is 9 chars: macOS `sun_path` tops out around 104 bytes and deep tmpdir socket paths (as used by existing tests) hit `listen EINVAL` with a longer suffix.
- The stat+unlink pair in `stop()` is not atomic (POSIX has no unlink-by-inode); the residual window is documented in-code and unreachable while the leader-lock protocol holds (successors bind only under the lock, which the old owner releases strictly after `stop()` resolves) — the same accepted fence-plus-documented-residual pattern as `replaceBrokerOwner`'s SIGTERM fence.

## Tests

`slack-bridge/broker/socket-server.test.ts` (in-process seam):
- `stop()` still removes the socket file it bound (guards against over-fencing).
- `stop()` preserves a successor's socket bound at the same path.

`slack-bridge/broker/replace-lifecycle.test.ts` (cross-process E2E per #953; children are real spawned `node` processes running the full `startBroker` composition — real lock file, real SQLite DB, real socket, real `admin.shutdown`):
- Graceful replace: child owner accepts `admin.shutdown` and stops; `replaceBrokerOwner` reports `replaced-graceful`; the lock changes hands exactly once (child releases its own lock, successor acquires); successor serves.
- Fenced-SIGTERM escalation: child accepts the RPC but never releases; replace escalates, the child dies by SIGTERM, and a normal successor start reclaims the stale lock.
- Non-owning shutdown in a separate process preserves the live owner's socket (the #953 regression proper).

Both regression tests were verified to **fail against the unfixed code** (in-process and cross-process variants) and pass with the fix. Per the issue notes, timeouts are generous and the assertion sets small; children use a readiness barrier, gate/result files, and kill-in-finally modeled on the `leader.test.ts` contender harness. Children load the repo's `.ts` sources directly via a `node:module` resolve hook under `--experimental-transform-types` (dist output is not committed and may be stale; CI's Node 24 supports the flag).

## Validation

- `pnpm prepush` (lint incl. agent-standards, typecheck, full test suite) green — 11/11 turbo tasks.
- Local `pr-reviewer` subagent pass: one P1 (stat→unlink TOCTOU) — addressed by documenting the residual window and its lock fencing as above; no other findings.
